### PR TITLE
check UHAL_VER_* instead of STD_UNORDERED_MAP

### DIFF
--- a/include/BUTool/helpers/StatusDisplay/StatusDisplay.hh
+++ b/include/BUTool/helpers/StatusDisplay/StatusDisplay.hh
@@ -1,10 +1,10 @@
 #ifndef __STATUS_DISPLAY_HH__
 #define __STATUS_DISPLAY_HH__
 
-#ifdef STD_UNORDERED_MAP
+#if UHAL_VER_MAJOR >= 2 && UHAL_VER_MINOR >= 8
 #include <unordered_map>
 typedef std::unordered_map<std::string, std::string> uMap;
-#else 
+#else
 #include <boost/unordered_map.hpp>
 typedef boost::unordered_map<std::string, std::string> uMap;
 #endif

--- a/include/BUTool/helpers/StatusDisplay/StatusDisplayCell.hh
+++ b/include/BUTool/helpers/StatusDisplay/StatusDisplayCell.hh
@@ -1,10 +1,10 @@
 #ifndef __STATUS_DISPLAY_CELL_HH__
 #define __STATUS_DISPLAY_CELL_HH__
 
-#ifdef STD_UNORDERED_MAP
+#if UHAL_VER_MAJOR >= 2 && UHAL_VER_MINOR >= 8
 #include <unordered_map>
 typedef std::unordered_map<std::string, std::string> uMap;
-#else 
+#else
 #include <boost/unordered_map.hpp>
 typedef boost::unordered_map<std::string, std::string> uMap;
 #endif

--- a/include/BUTool/helpers/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/BUTool/helpers/StatusDisplay/StatusDisplayMatrix.hh
@@ -1,10 +1,10 @@
 #ifndef __STATUS_DISPLAY_MATRIX_HH__
 #define __STATUS_DISPLAY_MATRIX_HH__
 
-#ifdef STD_UNORDERED_MAP
+#if UHAL_VER_MAJOR >= 2 && UHAL_VER_MINOR >= 8
 #include <unordered_map>
 typedef std::unordered_map<std::string, std::string> uMap;
-#else 
+#else
 #include <boost/unordered_map.hpp>
 typedef boost::unordered_map<std::string, std::string> uMap;
 #endif

--- a/mk/Makefile.local
+++ b/mk/Makefile.local
@@ -5,6 +5,8 @@ BUILD_MODE = x86
 export CACTUS_ROOT
 export UIO_UHAL_PATH
 
+UHAL_VER_MAJOR ?= 2
+UHAL_VER_MINOR ?= 7
 
 #x86 linux
 CXX=g++
@@ -81,7 +83,7 @@ EXECUTABLE_LIBRARIES = ${LIBRARIES} ${EXECUTABLE_LINKED_LIBRARY_FLAGS}
 
 CXX_FLAGS = -g -O3 -rdynamic -Wall -MMD -MP -fPIC ${INCLUDE_PATH} -Werror -Wno-literal-suffix
 
-CXX_FLAGS += -std=c++11 -fno-omit-frame-pointer -pedantic -Wno-ignored-qualifiers -Werror=return-type -Wextra -Wno-long-long -Winit-self -Wno-unused-local-typedefs  -Woverloaded-virtual ${COMPILETIME_ROOT} ${FALLTHROUGH_FLAGS} -Wno-unused-result
+CXX_FLAGS += -std=c++11 -fno-omit-frame-pointer -pedantic -Wno-ignored-qualifiers -Werror=return-type -Wextra -Wno-long-long -Winit-self -Wno-unused-local-typedefs  -Woverloaded-virtual -DUHAL_VER_MAJOR=${UHAL_VER_MAJOR} -DUHAL_VER_MINOR=${UHAL_VER_MINOR} ${COMPILETIME_ROOT} ${COMPILETIME_ROOT} ${FALLTHROUGH_FLAGS} -Wno-unused-result
 
 ifdef MAP_TYPE
 CXX_FLAGS += ${MAP_TYPE}


### PR DESCRIPTION
check for `UHAL_VER`s to be set instead of defining `STD_UNORDERED_MAP` - keep default version of uHAL to be 2.7.x