### PR TITLE
Introduce RemoveOutputStream() method to BUTextIO

### DIFF
--- a/include/BUTextIO/BUTextController.hh
+++ b/include/BUTextIO/BUTextController.hh
@@ -19,6 +19,7 @@ public:
     void Print(const char *fmt, ...);
     void Print(printer a);
     void AddOutputStream(std::ostream *os);
+    void RemoveOutputStream(std::ostream *os);
     void ResetStreams();
 };
 

--- a/include/BUTextIO/BUTextIO.hh
+++ b/include/BUTextIO/BUTextIO.hh
@@ -8,6 +8,7 @@ public:
     BUTextIO();
     virtual ~BUTextIO() {};
     void AddOutputStream(Level::level level, std::ostream *os);
+    void RemoveOutputStream(Level::level level, std::ostream* os);
     void ResetStreams(Level::level level);
     void Print(Level::level level, const char *fmt, ...);
 private:

--- a/src/BUTextIO/BUTextController.cc
+++ b/src/BUTextIO/BUTextController.cc
@@ -44,6 +44,18 @@ void BUTextController::AddOutputStream(std::ostream *os) {
     }
 }
 
+void BUTextController::RemoveOutputStream(std::ostream *os) {
+    std::vector<std::ostream*>::iterator it;
+    for (it=streams.begin(); it!=streams.end();) {
+        if (*it == os) {
+            it = streams.erase(it);
+        }
+        else {
+            ++it;
+        }
+    }
+}
+
 void BUTextController::ResetStreams() {
     streams.clear();
 }

--- a/src/BUTextIO/BUTextIO.cc
+++ b/src/BUTextIO/BUTextIO.cc
@@ -12,6 +12,10 @@ void BUTextIO::AddOutputStream(Level::level level, std::ostream *os) {
     controllers[level].AddOutputStream(os);
 }
 
+void BUTextIO::RemoveOutputStream(Level::level level, std::ostream* os) {
+    controllers[level].RemoveOutputStream(os);
+}
+
 void BUTextIO::ResetStreams(Level::level level) {
     controllers[level].ResetStreams();
 }


### PR DESCRIPTION
Introduce the `RemoveOutputStream()` method to BUTextIO in order to provide developer with a means of removing an `ostream` pointer from the vector of pointers. This ensures that, if the `ostream` object goes out of scope, it's pointer will not be accessed by the next `Print()` command, preventing a segfault. 