### PR TITLE
Require BUTextIO library for making helpers lib

### DIFF
--- a/mk/Makefile
+++ b/mk/Makefile
@@ -140,7 +140,7 @@ ${LIBRARY_TOOL_OBJECT_FILES}: obj/%.o : src/%.cc
 # ------------------------
 # helpers library
 # ------------------------
-${LIBRARY_HELPERS}: ${LIBRARY_HELPERS_OBJECT_FILES} ${LIBRARY_BUEXCEPTION}
+${LIBRARY_HELPERS}: ${LIBRARY_HELPERS_OBJECT_FILES} ${LIBRARY_BUEXCEPTION} ${LIBRARY_BUTEXTIO}
 	mkdir -p $(dir $@)
 	${CXX} ${LINK_LIBRARY_FLAGS} ${LIBRARY_HELPERS_OBJECT_FILES} -o $@
 


### PR DESCRIPTION
Hi @dgastler, for some of the `apollo-herd` builds, I kept getting the following error during the `BUTool` build, even in a clean build:

```
libBUTool_BUTextIO.so: file not recognized: File truncated
```

This is happening during the compilation of `libBUTool_Helpers.so`, which requires the linking of `libBUTool_BUTextIO.so`. I attached the full compiler commands below. But in the BUTool `Makefile` I don't see that `LIBRARY_BUTEXTIO` is a requirement for the compilation of `LIBRARY_HELPERS`. Could this be causing accessing the `libBUTool_BUTextIO.so` file before it's compilation is finished (especially in a multi-threaded job I guess)? 

In this PR I added that requirement, and `apollo-herd` builds with that addition don't seem to have the same error. I wanted to open this PR to ask your opinion on this, and if you think this is a fix, we can merge it to `release/v2.0`.

```
#7 499.6 g++ -shared -fPIC -Wall -g -O3 -rdynamic obj/BUTextIO/BUTextIO.o obj/BUTextIO/BUTextController.o obj/BUTextIO/Print.o -o lib/libBUTool_BUTextIO.so
#7 89.25 g++ -shared -fPIC -Wall -Wl,--no-as-needed -g -O3 -rdynamic -L/tmp/______________________________/apollo-herd/ApolloTool/BUTool/lib -L/tmp/______________________________/apollo-herd/ApolloTool/BUTool/external/BUException/lib -lToolException -lreadline -lcurses -lz -lboost_regex -lboost_program_options -ldl -lBUTool_BUTextIO -Wl,-rpath=/opt/BUTool/lib --sysroot=/ obj/BUTool/helpers/parseHelperss.o obj/StatusDisplay/StatusDisplay.o obj/StatusDisplay/StatusDisplayMatrix.o obj/StatusDisplay/StatusDisplayCell.o obj/RegisterHelper/RegisterHelperIO_converts.o obj/RegisterHelper/RegisterHelper.o obj/RegisterHelper/RegisterHelperIO.o -o lib/libBUTool_Helpers.so
#7 499.8 /tmp/______________________________/apollo-herd/ApolloTool/BUTool/lib/libBUTool_BUTextIO.so: file not recognized: File truncated
[599](https://gitlab.cern.ch/cms-tracker-phase2-onlinesw/apollo-herd/-/jobs/21619598#L599)#7 499.8 collect2: error: ld returned 1 exit status
[600](https://gitlab.cern.ch/cms-tracker-phase2-onlinesw/apollo-herd/-/jobs/21619598#L600)#7 499.8 make[1]: *** [lib/libBUTool_Helpers.so] Error 1
```

Example `apollo-herd` build: https://gitlab.cern.ch/cms-tracker-phase2-onlinesw/apollo-herd/-/jobs/21619598
 