### PR TITLE
Make StatusDisplay class use functionality from the RegisterHelperIO

### DIFF
--- a/include/BUTool/ToolException.hh
+++ b/include/BUTool/ToolException.hh
@@ -12,6 +12,7 @@ namespace BUException{
   ExceptionClassGenerator(REG_WRITE_DENIED,"Write access denied\n")
   ExceptionClassGenerator(BAD_REG_NAME,"Register name not found\n")
   ExceptionClassGenerator(BAD_VALUE,"Bad value\n")
+  ExceptionClassGenerator(BUS_ERROR,"Bus error encountered during a register read/write\n")
   // BUTextIO exception
   ExceptionClassGenerator(TEXTIO_BAD_INIT, "BUTool::RegisterHelper TextIO pointer is NULL\n Did you forget to call SetupTextIO() in the device's constructor?\n")
   // RegisterHelper exceptions

--- a/include/RegisterHelper/RegisterHelperIO.hh
+++ b/include/RegisterHelper/RegisterHelperIO.hh
@@ -63,6 +63,8 @@ namespace BUTool{
     virtual std::string GetRegHelp(std::string const & reg);
     virtual std::unordered_map<std::string,std::string> const & GetRegParameters(std::string const & reg);
     virtual std::string GetRegParameterValue(std::string const & reg, std::string const & name);
+    virtual std::string GetRegParameterValueWithDefault(std::string const & reg, std::string const & name,
+                                                        std::string const & defaultValue);
 
     //Handle address table name case (default is upper case)
     RegisterNameCase GetCase(){return regCase;};

--- a/include/RegisterHelper/RegisterHelperIO.hh
+++ b/include/RegisterHelper/RegisterHelperIO.hh
@@ -36,7 +36,7 @@ namespace BUTool{
     ConvertType                   GetConvertType(std::string const & reg);
     std::string                   GetConvertFormat(std::string const & reg);
     // Named register read+conversion functions, overloaded depending on the conversion value type
-    void                          ReadConvert(std::string const & reg, unsigned int & val);
+    void                          ReadConvert(std::string const & reg, uint64_t & val);
     void                          ReadConvert(std::string const & reg, int & val);
     void                          ReadConvert(std::string const & reg, double & val);
     void                          ReadConvert(std::string const & reg, std::string & val);

--- a/include/RegisterHelper/RegisterHelperIO.hh
+++ b/include/RegisterHelper/RegisterHelperIO.hh
@@ -31,6 +31,8 @@ namespace BUTool{
     virtual std::vector<uint32_t> BlockReadRegister(std::string const & reg,size_t count);
     virtual std::string           ReadString       (std::string const & reg);
 
+    uint64_t                      ComputeValueFromRegister(std::string const & reg);
+
     //convert functions
     enum ConvertType {NONE=0, UINT=1, INT=2, FP=4, STRING=8};
     ConvertType                   GetConvertType(std::string const & reg);
@@ -71,12 +73,12 @@ namespace BUTool{
     void ReCase(std::string & name);
   protected:
     // Helper functions for converting
-    double      ConvertFloatingPoint16ToDouble(std::string const & reg);
-    double      ConvertLinear11ToDouble(std::string const & reg);
-    double      ConvertIntegerToDouble(std::string const & reg, std::string const & format);
-    std::string ConvertEnumToString(std::string const & reg, std::string const & format);
-    std::string ConvertIPAddressToString(std::string const & reg);
-    std::string ConvertHexNumberToString(std::string const & reg);
+    double      ConvertFloatingPoint16ToDouble(uint64_t rawValue);
+    double      ConvertLinear11ToDouble(uint64_t rawValue);
+    double      ConvertIntegerToDouble(uint64_t rawValue, std::string const & format);
+    std::string ConvertEnumToString(uint64_t rawValue, std::string const & format);
+    std::string ConvertIPAddressToString(uint64_t rawValue);
+    std::string ConvertHexNumberToString(uint64_t rawValue);
 
   private:
     RegisterNameCase regCase;

--- a/include/RegisterHelper/RegisterHelperIO.hh
+++ b/include/RegisterHelper/RegisterHelperIO.hh
@@ -76,6 +76,7 @@ namespace BUTool{
     double      ConvertIntegerToDouble(std::string const & reg, std::string const & format);
     std::string ConvertEnumToString(std::string const & reg, std::string const & format);
     std::string ConvertIPAddressToString(std::string const & reg);
+    std::string ConvertHexNumberToString(std::string const & reg);
 
   private:
     RegisterNameCase regCase;

--- a/include/RegisterHelper/RegisterHelperIO.hh
+++ b/include/RegisterHelper/RegisterHelperIO.hh
@@ -37,7 +37,7 @@ namespace BUTool{
     std::string                   GetConvertFormat(std::string const & reg);
     // Named register read+conversion functions, overloaded depending on the conversion value type
     void                          ReadConvert(std::string const & reg, uint64_t & val);
-    void                          ReadConvert(std::string const & reg, int & val);
+    void                          ReadConvert(std::string const & reg, int64_t & val);
     void                          ReadConvert(std::string const & reg, double & val);
     void                          ReadConvert(std::string const & reg, std::string & val);
     

--- a/include/RegisterHelper/RegisterHelperIO.hh
+++ b/include/RegisterHelper/RegisterHelperIO.hh
@@ -63,8 +63,6 @@ namespace BUTool{
     virtual std::string GetRegHelp(std::string const & reg);
     virtual std::unordered_map<std::string,std::string> const & GetRegParameters(std::string const & reg);
     virtual std::string GetRegParameterValue(std::string const & reg, std::string const & name);
-    virtual std::string GetRegParameterValueWithDefault(std::string const & reg, std::string const & name,
-                                                        std::string const & defaultValue);
 
     //Handle address table name case (default is upper case)
     RegisterNameCase GetCase(){return regCase;};

--- a/include/StatusDisplay/StatusDisplay.hh
+++ b/include/StatusDisplay/StatusDisplay.hh
@@ -101,7 +101,7 @@ namespace BUTool{
     RegisterHelperIO * regIO;
     void AppendAuthor(std::string const & author);
     void SetTitle(std::string const & _title){title=_title;};
-    virtual void Process(std::string const & singleTable) = 0;
+    void Process(std::string const & singleTable);
     std::map<std::string,StatusDisplayMatrix> tables;
     void SetVersion(int ver){version = ver;};
   private:

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -55,7 +55,8 @@ namespace BUTool{
     std::string const & GetDesc() const;
     std::string const & GetAddress() const;
 
-    void FormatHexString(char * buffer, int bufferSize, int width = -1) const;
+    void ReadAndFormatHexString(char * buffer, int bufferSize, int width = -1) const;
+    void ReadAndFormatDouble(char * buffer, int bufferSize, int width = -1) const;
 
     void SetAddress(std::string const & _address);
     uint32_t const & GetMask() const;

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -55,6 +55,8 @@ namespace BUTool{
     std::string const & GetDesc() const;
     std::string const & GetAddress() const;
 
+    void FormatHexString(char const & buffer, int width = -1) const;
+
     void SetAddress(std::string const & _address);
     uint32_t const & GetMask() const;
     void SetMask(uint32_t const & _mask);

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -70,10 +70,6 @@ namespace BUTool{
 		       std::string const & thing2) const;
     uint64_t ComputeValue() const;
 
-    std::string GetRegParameterValueWithDefault(std::string const & reg, 
-                      std::string const & name,
-                      std::string const & defaultValue);
-
     std::string address;
     std::string description;
     std::string row;

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -17,6 +17,8 @@ typedef boost::unordered_map<std::string, std::string> uMap;
 #include <boost/tokenizer.hpp> //for tokenizer
 #include <cmath> // for pow
 
+#include "RegisterHelper/RegisterHelperIO.hh"
+
 namespace BUTool{
 
   /*! \brief One cell in a status display.
@@ -31,14 +33,15 @@ namespace BUTool{
     StatusDisplayCell(){Clear();};
     ~StatusDisplayCell(){Clear();};
     ///! Fill in values for a cell
-    void Setup(std::string const & _address,  /// address table name stripped of Hi/Lo
-	       std::string const & _description, /// long description
-	       std::string const & _row,	 /// display row
-	       std::string const & _col,	 /// display column
-	       std::string const & _format,	 /// display format
-	       std::string const & _rule,	 /// nz, z, nzr etc
-	       std::string const & _statusLevel, /// status level to display
-	       bool enabled = true);             /// enabled status
+    void Setup(RegisterHelperIO * _regIO, // RegisterHelperIO instance to do reads 
+        std::string const & _address,  /// address table name stripped of Hi/Lo
+	      std::string const & _description, /// long description
+	      std::string const & _row,	 /// display row
+	      std::string const & _col,	 /// display column
+	      std::string const & _format,	 /// display format
+	      std::string const & _rule,	 /// nz, z, nzr etc
+	      std::string const & _statusLevel, /// status level to display
+	      bool enabled = true);             /// enabled status
     ///! store a value plus a shift for a multi-word value
     void Fill(uint32_t value,
 	      size_t bitShift = 0);
@@ -61,7 +64,8 @@ namespace BUTool{
     void SetEnabled(bool d){enabled = d;}
     bool GetEnabled(){return enabled;}
 
-  private:    
+  private:
+    RegisterHelperIO * regIO;    
     void Clear();
     void CheckAndThrow(std::string const & name,
 		       std::string & thing1,

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -55,7 +55,7 @@ namespace BUTool{
     std::string const & GetDesc() const;
     std::string const & GetAddress() const;
 
-    void FormatHexString(char const & buffer, int bufferSize, int width = -1) const;
+    void FormatHexString(char * buffer, int bufferSize, int width = -1) const;
 
     void SetAddress(std::string const & _address);
     uint32_t const & GetMask() const;

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -40,9 +40,6 @@ namespace BUTool{
 	      std::string const & _row,	 /// display row
 	      std::string const & _col 	 /// display column
 	      );
-    ///! store a value plus a shift for a multi-word value
-    void Fill(uint32_t value,
-	      size_t bitShift = 0);
 
     ///! Determine if this cell should be displayed based on rule, statusLevel
     bool Display(int level,bool force = false) const;
@@ -73,7 +70,6 @@ namespace BUTool{
     void CheckAndThrow(std::string const & name,
 		       std::string & thing1,
 		       std::string const & thing2) const;
-    uint64_t ComputeValue() const;
 
     std::string address;
     std::string description;
@@ -83,8 +79,6 @@ namespace BUTool{
 
     uint32_t mask;
     
-    std::vector<uint32_t > word;
-    std::vector<int> wordShift;
     std::string format;
     std::string displayRule;   
     RegisterHelperIO::ConvertType convertType;

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -55,7 +55,7 @@ namespace BUTool{
     std::string const & GetDesc() const;
     std::string const & GetAddress() const;
 
-    void FormatHexString(char const & buffer, int width = -1) const;
+    void FormatHexString(char const & buffer, int bufferSize, int width = -1) const;
 
     void SetAddress(std::string const & _address);
     uint32_t const & GetMask() const;

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -70,6 +70,10 @@ namespace BUTool{
 		       std::string const & thing2) const;
     uint64_t ComputeValue() const;
 
+    std::string GetRegParameterValueWithDefault(std::string const & reg, 
+                      std::string const & name,
+                      std::string const & defaultValue);
+
     std::string address;
     std::string description;
     std::string row;

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -38,7 +38,7 @@ namespace BUTool{
     void Setup(RegisterHelperIO * _regIO, // RegisterHelperIO instance to do reads 
         std::string const & _address,  /// address table name stripped of Hi/Lo
 	      std::string const & _row,	 /// display row
-	      std::string const & _col,	 /// display column
+	      std::string const & _col 	 /// display column
 	      );
     ///! store a value plus a shift for a multi-word value
     void Fill(uint32_t value,

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -19,6 +19,8 @@ typedef boost::unordered_map<std::string, std::string> uMap;
 
 #include "RegisterHelper/RegisterHelperIO.hh"
 
+#define STATUS_DISPLAY_DEFAULT_FORMAT "X"
+
 namespace BUTool{
 
   /*! \brief One cell in a status display.
@@ -35,13 +37,9 @@ namespace BUTool{
     ///! Fill in values for a cell
     void Setup(RegisterHelperIO * _regIO, // RegisterHelperIO instance to do reads 
         std::string const & _address,  /// address table name stripped of Hi/Lo
-	      std::string const & _description, /// long description
 	      std::string const & _row,	 /// display row
 	      std::string const & _col,	 /// display column
-	      std::string const & _format,	 /// display format
-	      std::string const & _rule,	 /// nz, z, nzr etc
-	      std::string const & _statusLevel, /// status level to display
-	      bool enabled = true);             /// enabled status
+	      );
     ///! store a value plus a shift for a multi-word value
     void Fill(uint32_t value,
 	      size_t bitShift = 0);
@@ -84,6 +82,7 @@ namespace BUTool{
     std::vector<int> wordShift;
     std::string format;
     std::string displayRule;   
+    RegisterHelperIO::ConvertType convertType;
     int statusLevel;
   };
 

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -56,7 +56,9 @@ namespace BUTool{
     std::string const & GetAddress() const;
 
     void ReadAndFormatHexString(char * buffer, int bufferSize, int width = -1) const;
-    void ReadAndFormatDouble(char * buffer, int bufferSize, int width = -1) const;
+    void ReadAndFormatDouble   (char * buffer, int bufferSize, int width = -1) const;
+    void ReadAndFormatInt      (char * buffer, int bufferSize, int width = -1) const;
+    void ReadAndFormatUInt     (char * buffer, int bufferSize, int width = -1) const;
 
     void SetAddress(std::string const & _address);
     uint32_t const & GetMask() const;

--- a/include/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/StatusDisplay/StatusDisplayMatrix.hh
@@ -16,7 +16,7 @@ typedef boost::unordered_map<std::string, std::string> uMap;
 #include <map>
 #include <boost/tokenizer.hpp> //for tokenizer
 #include "StatusDisplayCell.hh"
-
+#include "RegisterHelper/RegisterHelperIO.hh"
 
 #define STATUS_DISPLAY_DEFAULT_FORMAT "X"
 #define STATUS_DISPLAY_PARAMETER_PARSE_TOKEN '_'
@@ -38,6 +38,7 @@ namespace BUTool{
   public:
     StatusDisplayMatrix(){Clear();};
     ~StatusDisplayMatrix(){Clear();};
+    void Add(std::string registerName, RegisterHelperIO* regIO);
     void Add(std::string  address,uint32_t value, uint32_t value_mask, uMap const & parameters);
     void Render(std::ostream & stream,int status,StatusMode statusMode = TEXT) const;
     std::vector<std::string> GetTableRows() const;

--- a/include/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/StatusDisplay/StatusDisplayMatrix.hh
@@ -52,6 +52,8 @@ namespace BUTool{
           std::vector<std::string> const & parsedName) const;
     std::string BuildNameWithMultipleUnderscores(std::string const & markup,
           std::vector<std::string> const & parsedName) const;
+    void CheckForInvalidCharacter(std::string const & name
+          std::string const & invalidChar) const;
     void CheckName(std::string const & newName);
     std::string ParseRowOrCol(RegisterHelperIO* regIO,
 			 std::string const & addressBase,

--- a/include/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/StatusDisplay/StatusDisplayMatrix.hh
@@ -38,7 +38,7 @@ namespace BUTool{
   public:
     StatusDisplayMatrix(){Clear();};
     ~StatusDisplayMatrix(){Clear();};
-    void Add(std::string registerName, RegisterHelperIO* regIO);
+    void Add(std::string registerName, RegisterHelperIO* regIO, uMap const & parameters);
     void Add(std::string  address,uint32_t value, uint32_t value_mask, uMap const & parameters);
     void Render(std::ostream & stream,int status,StatusMode statusMode = TEXT) const;
     std::vector<std::string> GetTableRows() const;

--- a/include/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/StatusDisplay/StatusDisplayMatrix.hh
@@ -56,7 +56,7 @@ namespace BUTool{
           char const & invalidChar) const;
     void CheckName(std::string const & newName);
     std::string ParseRowOrCol(RegisterHelperIO* regIO,
-			 std::string const & addressBase,
+			 std::string const & registerName,
        std::string const & parameterName) const;
 
     std::vector<StatusDisplayCell*> row(std::string const &);

--- a/include/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/StatusDisplay/StatusDisplayMatrix.hh
@@ -38,8 +38,7 @@ namespace BUTool{
   public:
     StatusDisplayMatrix(){Clear();};
     ~StatusDisplayMatrix(){Clear();};
-    void Add(std::string registerName, RegisterHelperIO* regIO, uMap const & parameters);
-    void Add(std::string  address,uint32_t value, uint32_t value_mask, uMap const & parameters);
+    void Add(std::string registerName, RegisterHelperIO* regIO);
     void Render(std::ostream & stream,int status,StatusMode statusMode = TEXT) const;
     std::vector<std::string> GetTableRows() const;
     std::vector<std::string> GetTableColumns() const;
@@ -50,10 +49,9 @@ namespace BUTool{
     std::string NameBuilder(std::string const & markup,
 			    std::string const & name) const;
     void CheckName(std::string const & newName);
-    std::string ParseRow(uMap const & parameters,
-			 std::string const & addressBase) const;
-    std::string ParseCol(uMap const & parameters,
-			 std::string const & addressBase) const;
+    std::string ParseRowOrCol(RegisterHelperIO* regIO,
+			 std::string const & addressBase,
+       std::string const & parameterName) const;
 
     std::vector<StatusDisplayCell*> row(std::string const &);
     std::vector<StatusDisplayCell*> col(std::string const &);

--- a/include/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/StatusDisplay/StatusDisplayMatrix.hh
@@ -47,11 +47,11 @@ namespace BUTool{
     void Clear();
     
     std::string NameBuilder(std::string const & markup,
-			    std::string const & name) const;
+			    std::string const & registerName) const;
     std::string BuildNameWithSingleUnderscore(std::string const & markup,
-          std::string const & name) const;
+          std::vector<std::string> const & parsedName) const;
     std::string BuildNameWithMultipleUnderscores(std::string const & markup,
-          std::string const & name) const;
+          std::vector<std::string> const & parsedName) const;
     void CheckName(std::string const & newName);
     std::string ParseRowOrCol(RegisterHelperIO* regIO,
 			 std::string const & addressBase,

--- a/include/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/StatusDisplay/StatusDisplayMatrix.hh
@@ -48,6 +48,10 @@ namespace BUTool{
     
     std::string NameBuilder(std::string const & markup,
 			    std::string const & name) const;
+    std::string BuildNameWithSingleUnderscore(std::string const & markup,
+          std::string const & name) const;
+    std::string BuildNameWithMultipleUnderscores(std::string const & markup,
+          std::string const & name) const;
     void CheckName(std::string const & newName);
     std::string ParseRowOrCol(RegisterHelperIO* regIO,
 			 std::string const & addressBase,

--- a/include/StatusDisplay/StatusDisplayMatrix.hh
+++ b/include/StatusDisplay/StatusDisplayMatrix.hh
@@ -52,8 +52,8 @@ namespace BUTool{
           std::vector<std::string> const & parsedName) const;
     std::string BuildNameWithMultipleUnderscores(std::string const & markup,
           std::vector<std::string> const & parsedName) const;
-    void CheckForInvalidCharacter(std::string const & name
-          std::string const & invalidChar) const;
+    void CheckForInvalidCharacter(std::string const & name,
+          char const & invalidChar) const;
     void CheckName(std::string const & newName);
     std::string ParseRowOrCol(RegisterHelperIO* regIO,
 			 std::string const & addressBase,

--- a/mk/Makefile
+++ b/mk/Makefile
@@ -73,6 +73,10 @@ ifdef MAP_TYPE
 CXX_FLAGS += ${MAP_TYPE}
 endif
 
+ifeq (${BUTOOL_SD_NEW}, true)
+CXX_FLAGS += -DBUILD_UPDATED_ROW_COL_NAMES
+endif
+
 LINK_LIBRARY_FLAGS = -shared -fPIC -Wall -Wl,--no-as-needed -g -O3 -rdynamic ${LIBRARY_PATH} ${LIBRARIES} -Wl,-rpath=${RUNTIME_LDPATH}/lib ${COMPILETIME_ROOT}
 
 LINK_EXECUTABLE_FLAGS = -Wall -Wl,--no-as-needed -g -O3 -rdynamic ${LIBRARY_PATH} ${EXECUTABLE_LIBRARIES} -Wl,-rpath=${RUNTIME_LDPATH}/lib ${COMPILETIME_ROOT}

--- a/mk/Makefile
+++ b/mk/Makefile
@@ -73,8 +73,9 @@ ifdef MAP_TYPE
 CXX_FLAGS += ${MAP_TYPE}
 endif
 
-ifeq (${BUTOOL_SD_NEW}, true)
-CXX_FLAGS += -DBUILD_UPDATED_ROW_COL_NAMES
+# Compile-time flag to specify to use the new StatusDisplay name parser for row and column names
+ifeq (${BUTOOL_SD_USE_NEW_PARSER}, true)
+CXX_FLAGS += -DSD_USE_NEW_PARSER
 endif
 
 LINK_LIBRARY_FLAGS = -shared -fPIC -Wall -Wl,--no-as-needed -g -O3 -rdynamic ${LIBRARY_PATH} ${LIBRARIES} -Wl,-rpath=${RUNTIME_LDPATH}/lib ${COMPILETIME_ROOT}

--- a/src/RegisterHelper/RegisterHelper.cc
+++ b/src/RegisterHelper/RegisterHelper.cc
@@ -119,7 +119,7 @@ CommandReturn::status BUTool::RegisterHelper::ReadConvert(std::vector<std::strin
         int64_t val;
         regIO->ReadConvert(reg, val);
         // Display the value to the screen
-        TextIO->Print(Level::INFO, "%50s: " PRId64 "\n",reg.c_str(),val);
+        TextIO->Print(Level::INFO, "%50s: %" PRId64 "\n",reg.c_str(),val);
         break;
       }
     case  RegisterHelperIO::UINT:
@@ -128,7 +128,7 @@ CommandReturn::status BUTool::RegisterHelper::ReadConvert(std::vector<std::strin
         uint64_t val;
         regIO->ReadConvert(reg, val);
         // Display the value to the screen
-        TextIO->Print(Level::INFO, "%50s: 0x" PRIx64 "\n",reg.c_str(),val);
+        TextIO->Print(Level::INFO, "%50s: 0x%" PRIX64 "\n",reg.c_str(),val);
         break;
       }
     }

--- a/src/RegisterHelper/RegisterHelper.cc
+++ b/src/RegisterHelper/RegisterHelper.cc
@@ -125,7 +125,7 @@ CommandReturn::status BUTool::RegisterHelper::ReadConvert(std::vector<std::strin
     case  RegisterHelperIO::UINT:
     default: 
       {
-        unsigned int val;
+        uint64_t val;
         regIO->ReadConvert(reg, val);
         // Display the value to the screen
         TextIO->Print(Level::INFO, "%50s: 0x%08X\n",reg.c_str(),val);

--- a/src/RegisterHelper/RegisterHelper.cc
+++ b/src/RegisterHelper/RegisterHelper.cc
@@ -116,7 +116,7 @@ CommandReturn::status BUTool::RegisterHelper::ReadConvert(std::vector<std::strin
       }
       case RegisterHelperIO::INT:
       {
-        int val;
+        int64_t val;
         regIO->ReadConvert(reg, val);
         // Display the value to the screen
         TextIO->Print(Level::INFO, "%50s: %d\n",reg.c_str(),val);

--- a/src/RegisterHelper/RegisterHelper.cc
+++ b/src/RegisterHelper/RegisterHelper.cc
@@ -119,7 +119,7 @@ CommandReturn::status BUTool::RegisterHelper::ReadConvert(std::vector<std::strin
         int64_t val;
         regIO->ReadConvert(reg, val);
         // Display the value to the screen
-        TextIO->Print(Level::INFO, "%50s: %d\n",reg.c_str(),val);
+        TextIO->Print(Level::INFO, "%50s: " PRId64 "\n",reg.c_str(),val);
         break;
       }
     case  RegisterHelperIO::UINT:
@@ -128,7 +128,7 @@ CommandReturn::status BUTool::RegisterHelper::ReadConvert(std::vector<std::strin
         uint64_t val;
         regIO->ReadConvert(reg, val);
         // Display the value to the screen
-        TextIO->Print(Level::INFO, "%50s: 0x%08X\n",reg.c_str(),val);
+        TextIO->Print(Level::INFO, "%50s: 0x" PRIx64 "\n",reg.c_str(),val);
         break;
       }
     }

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -139,13 +139,21 @@ void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, int & val){
   // Read the value from the named register, and update the value in place
   int rawVal = ReadRegister(reg); //convert bits to int from uint32_t
   int mask   = GetRegMask(reg);
-  //mask is in the raw 32bit space, so not already alined to bit zero like rawVal.
-  //We need to shift it until we get a 1 in the 0th space
-  while(!(mask&0x1)){
-    mask = mask >> 1;
+
+  // Count number of bits in the mask
+  uint64_t b;
+  // Shift all the bits to right until we count all the bits in the mask
+  for (b=0; mask; mask >>= 1)
+  {
+    b += mask & 1;
   }
-  //Do the conversion (from stanford bit twiddling hacks)
-  val = (rawVal ^ mask) - mask; 
+
+  // Sign extend b-bit number to r
+  int x = rawVal;
+  int const m = 1U << (b - 1); 
+
+  x = x & ((1U << b) - 1);
+  val = (x ^ m) - m;
 }
 
 void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, double & val){

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -130,7 +130,7 @@ uint64_t BUTool::RegisterHelperIO::ComputeValueFromRegister(std::string const & 
   Reads the raw 32-bit unsigned integer value from the register, and returns a 64-bit
   unsigned integer.
 
-  If the register name ("reg") contains a "_LOW" or "_HI", this function will handle the
+  If the register name ("reg") contains a "_LO" or "_HI", this function will handle the
   merging of the 32-bit values and return the merged value.
   */
   uint32_t rawValue = ReadRegister(reg);
@@ -214,7 +214,8 @@ void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, int64_t & va
     b += mask & 1;
   }
 
-  // Sign extend b-bit number to r
+  // Sign extend b-bit number, override the value in x
+  // See here: https://graphics.stanford.edu/~seander/bithacks.html#FixedSignExtend
   int64_t x = rawVal;
   int64_t const m = 1U << (b - 1); 
 

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -175,7 +175,8 @@ uint64_t BUTool::RegisterHelperIO::ComputeValueFromRegister(std::string const & 
   }
 
   // Check if this register contains a "_HI", so it is going to be merged with a "_LO"
-  else if ( reg.find("_HI") == reg.size()-3 ) {
+  // (the only possibility at this point)
+  else {
     std::string baseRegisterName = reg.substr(0,reg.find("_HI"));
 
     // Name of the corresponding "_LO" register

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -225,3 +225,11 @@ std::string BUTool::RegisterHelperIO::GetRegParameterValue(std::string const & /
   throw e;
   return std::string("");
 }
+
+std::string BUTool::RegisterHelperIO::GetRegParameterValueWithDefault(std::string const & /*reg*/, std::string const & /*name*/,
+                                                        std::string const & /*defaultValue*/){
+  BUException::FUNCTION_NOT_IMPLEMENTED e;
+  e.Append("GetRegParameterValueWithDefault wasn't overloaded, but called\n");
+  throw e;
+  return std::string("");
+}

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -135,7 +135,7 @@ void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, uint64_t & v
 }
 
 
-void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, int & val){
+void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, int64_t & val){
   // Read the value from the named register, and update the value in place
   int rawVal = ReadRegister(reg); //convert bits to int from uint32_t
   int mask   = GetRegMask(reg);

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -134,7 +134,6 @@ uint64_t BUTool::RegisterHelperIO::ComputeValueFromRegister(std::string const & 
   merging of the 32-bit values and return the merged value.
   */
   uint32_t rawValue = ReadRegister(reg);
-  uint32_t regMask = GetRegMask(reg);
 
   // 64-bit unsigned integer we're going to return
   uint64_t result;
@@ -146,16 +145,17 @@ uint64_t BUTool::RegisterHelperIO::ComputeValueFromRegister(std::string const & 
   }
 
   // Below this line, merging of different values is handled
+  uint32_t regMask = GetRegMask(reg);
 
   // Figure out the number of bit shifts from the size of the word
   // 32 bits is the default, but it will be less for smaller values
   int numBitShifts = 32;
   
-  while ( (mask & 0x1) == 0 ) { mask >>= 1; }
+  while ( (regMask & 0x1) == 0 ) { regMask >>= 1; }
   int count = 0;
-  while ( (mask & 0x1) == 1 ) {
+  while ( (regMask & 0x1) == 1 ) {
     count++;
-    mask >>= 1;
+    regMask >>= 1;
   }
   numBitShifts = count;
   

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -190,7 +190,7 @@ void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, std::string 
   }
   // Hex numbers in string
   else if ((format[0] == 'X') || (format[0] == 'x')) {
-    val = ReadRegister(reg);
+    val = ConvertHexNumberToString(reg);
   }
   // Undefined format, throw error
   else {

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -225,11 +225,3 @@ std::string BUTool::RegisterHelperIO::GetRegParameterValue(std::string const & /
   throw e;
   return std::string("");
 }
-
-std::string BUTool::RegisterHelperIO::GetRegParameterValueWithDefault(std::string const & /*reg*/, std::string const & /*name*/,
-                                                        std::string const & /*defaultValue*/){
-  BUException::FUNCTION_NOT_IMPLEMENTED e;
-  e.Append("GetRegParameterValueWithDefault wasn't overloaded, but called\n");
-  throw e;
-  return std::string("");
-}

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -128,7 +128,7 @@ void BUTool::RegisterHelperIO::ReCase(std::string & name){
 
 
 
-void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, unsigned int & val){
+void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, uint64_t & val){
   // Read the value from the named register, and update the value in place
   uint32_t rawVal = ReadRegister(reg);
   val = rawVal;

--- a/src/RegisterHelper/RegisterHelperIO_converts.cc
+++ b/src/RegisterHelper/RegisterHelperIO_converts.cc
@@ -181,9 +181,7 @@ double BUTool::RegisterHelperIO::ConvertLinear11ToDouble(uint64_t rawValue){
 std::string BUTool::RegisterHelperIO::ConvertIPAddressToString(uint64_t rawValue){
   // Helper function to convert IP addresses to string
   struct in_addr addr;
-  int16_t val = rawValue; 
-  addr.s_addr = in_addr_t(val);
-
+  addr.s_addr = in_addr_t(rawValue);
   return inet_ntoa(addr);
 }
 

--- a/src/RegisterHelper/RegisterHelperIO_converts.cc
+++ b/src/RegisterHelper/RegisterHelperIO_converts.cc
@@ -9,6 +9,10 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
+//For PRI macros
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
 std::string BUTool::RegisterHelperIO::GetConvertFormat(std::string const & reg){
   // From a given node address, retrieve the "Format" parameter of the node
   auto parameter = GetRegParameters(reg);
@@ -244,15 +248,30 @@ std::string BUTool::RegisterHelperIO::ConvertEnumToString(std::string const & re
   // Now we have the enumeration map, read the integer value from the register
   // Then return the corresponding string
   uint32_t regValue = ReadRegister(reg);
+
+  // Store the result in this C-style buffer
+  // This function will return the content in this buffer
+  // after converting it into a C++ string 
+  const int bufferSize = 20;
+  char buffer[bufferSize+1];
+  memset(buffer,' ',20);
+  buffer[bufferSize] = '\0';
+
   if (enumMap.find(regValue) != enumMap.end()) {
     // If format starts with 't', just return the string value
     // Otherwise, return the value together with the number
     if (format[0] == 't') {
-      return enumMap[regValue].c_str();
+      snprintf(buffer,bufferSize,"%s",enumMap[regValue].c_str());
     }
-    return (enumMap[regValue] + " " + std::to_string(regValue)).c_str();
+    else {
+      snprintf(buffer,bufferSize,"%s (0x%" PRIX64 ")",enumMap[regValue].c_str(),regValue);
+    }
+  }
+  
+  // Could not find the value in enumeration map
+  else {
+    snprintf(buffer,bufferSize,"0x%" PRIX64 ")",regValue);
   }
 
-  // Cannot find it, TODO: better handle this possibility
-  return "NOT_FOUND";
+  return std::string(buffer);
 }

--- a/src/RegisterHelper/RegisterHelperIO_converts.cc
+++ b/src/RegisterHelper/RegisterHelperIO_converts.cc
@@ -264,13 +264,13 @@ std::string BUTool::RegisterHelperIO::ConvertEnumToString(std::string const & re
       snprintf(buffer,bufferSize,"%s",enumMap[regValue].c_str());
     }
     else {
-      snprintf(buffer,bufferSize,"%s (0x%" PRIX64 ")",enumMap[regValue].c_str(),regValue);
+      snprintf(buffer,bufferSize,"%s (0x%" PRIX64 ")",enumMap[regValue].c_str(),uint64_t(regValue));
     }
   }
   
   // Could not find the value in enumeration map
   else {
-    snprintf(buffer,bufferSize,"0x%" PRIX64 ")",regValue);
+    snprintf(buffer,bufferSize,"0x%" PRIX64 ")",uint64_t(regValue));
   }
 
   return std::string(buffer);
@@ -288,7 +288,7 @@ std::string BUTool::RegisterHelperIO::ConvertHexNumberToString(std::string const
   char buffer[bufferSize+1];
   buffer[bufferSize] = '\0';
 
-  snprintf(buffer, bufferSize, "0x%" PRIX64, regValue);
+  snprintf(buffer, bufferSize, "0x%" PRIX64, uint64_t(regValue));
 
   return std::string(buffer);
 }

--- a/src/RegisterHelper/RegisterHelperIO_converts.cc
+++ b/src/RegisterHelper/RegisterHelperIO_converts.cc
@@ -59,7 +59,7 @@ BUTool::RegisterHelperIO::ConvertType BUTool::RegisterHelperIO::GetConvertType(s
 }
 
 
-double BUTool::RegisterHelperIO::ConvertFloatingPoint16ToDouble(std::string const & reg){
+double BUTool::RegisterHelperIO::ConvertFloatingPoint16ToDouble(uint64_t rawValue){
   // Helper function to do the "fp16->double" conversion
   double doubleVal;
 
@@ -71,7 +71,7 @@ double BUTool::RegisterHelperIO::ConvertFloatingPoint16ToDouble(std::string cons
     } fp16;
     int16_t raw;
   } val;
-  val.raw = ReadRegister(reg);
+  val.raw = rawValue;
 
   switch (val.fp16.exponent) {
   // Case where the exponent is minimum
@@ -112,7 +112,7 @@ double BUTool::RegisterHelperIO::ConvertFloatingPoint16ToDouble(std::string cons
   return doubleVal;
 }
 
-double BUTool::RegisterHelperIO::ConvertIntegerToDouble(std::string const & reg, std::string const & format){
+double BUTool::RegisterHelperIO::ConvertIntegerToDouble(uint64_t rawValue, std::string const & format){
   // Helper function to convert an integer to float using the following format:
   // y = (sign)*(M_n/M_d)*x + (sign)*(b_n/b_d)
   //       [0]   [1] [2]        [3]   [4] [5]
@@ -120,8 +120,6 @@ double BUTool::RegisterHelperIO::ConvertIntegerToDouble(std::string const & reg,
 
   std::vector<uint64_t> mathValues;
   size_t iFormat=1;
- 
-  uint32_t rawVal = ReadRegister(reg);
  
   while (mathValues.size() != 6 && iFormat < format.size()) {
     if (format[iFormat] == '_') {
@@ -146,7 +144,7 @@ double BUTool::RegisterHelperIO::ConvertIntegerToDouble(std::string const & reg,
 
   // Compute the transformed value from the raw value
   // Will compute: (m*x) + b
-  double transformedValue = rawVal;
+  double transformedValue = rawValue;
   transformedValue *= double(mathValues[1]);
   transformedValue /= double(mathValues[2]);
   // Apply the sign of m
@@ -163,7 +161,7 @@ double BUTool::RegisterHelperIO::ConvertIntegerToDouble(std::string const & reg,
   return transformedValue;
 }
 
-double BUTool::RegisterHelperIO::ConvertLinear11ToDouble(std::string const & reg){
+double BUTool::RegisterHelperIO::ConvertLinear11ToDouble(uint64_t rawValue){
   // Helper function to convert linear11 format to double
 
   union {
@@ -174,16 +172,16 @@ double BUTool::RegisterHelperIO::ConvertLinear11ToDouble(std::string const & reg
     int16_t raw;
   } val;
   
-  val.raw = ReadRegister(reg);
+  val.raw = rawValue;
   double floatingValue = double(val.linear11.integer) * pow(2, val.linear11.exponent);
   
   return floatingValue;
 }
 
-std::string BUTool::RegisterHelperIO::ConvertIPAddressToString(std::string const & reg){
+std::string BUTool::RegisterHelperIO::ConvertIPAddressToString(uint64_t rawValue){
   // Helper function to convert IP addresses to string
   struct in_addr addr;
-  int16_t val = ReadRegister(reg);
+  int16_t val = rawValue; 
   addr.s_addr = in_addr_t(val);
 
   return inet_ntoa(addr);
@@ -210,7 +208,7 @@ std::vector<std::string> BUTool::RegisterHelperIO::FindRegistersWithParameter(st
   return registerNames;
 }
 
-std::string BUTool::RegisterHelperIO::ConvertEnumToString(std::string const & reg, std::string const & format){
+std::string BUTool::RegisterHelperIO::ConvertEnumToString(uint64_t rawValue, std::string const & format){
   // Helper function to convert enum to std::string
   std::map<uint64_t, std::string> enumMap;
   
@@ -247,7 +245,6 @@ std::string BUTool::RegisterHelperIO::ConvertEnumToString(std::string const & re
 
   // Now we have the enumeration map, read the integer value from the register
   // Then return the corresponding string
-  uint32_t regValue = ReadRegister(reg);
 
   // Store the result in this C-style buffer
   // This function will return the content in this buffer
@@ -257,30 +254,27 @@ std::string BUTool::RegisterHelperIO::ConvertEnumToString(std::string const & re
   memset(buffer,' ',20);
   buffer[bufferSize] = '\0';
 
-  if (enumMap.find(regValue) != enumMap.end()) {
+  if (enumMap.find(rawValue) != enumMap.end()) {
     // If format starts with 't', just return the string value
     // Otherwise, return the value together with the number
     if (format[0] == 't') {
-      snprintf(buffer,bufferSize,"%s",enumMap[regValue].c_str());
+      snprintf(buffer,bufferSize,"%s",enumMap[rawValue].c_str());
     }
     else {
-      snprintf(buffer,bufferSize,"%s (0x%" PRIX64 ")",enumMap[regValue].c_str(),uint64_t(regValue));
+      snprintf(buffer,bufferSize,"%s (0x%" PRIX64 ")",enumMap[rawValue].c_str(),rawValue);
     }
   }
   
   // Could not find the value in enumeration map
   else {
-    snprintf(buffer,bufferSize,"0x%" PRIX64 ")",uint64_t(regValue));
+    snprintf(buffer,bufferSize,"0x%" PRIX64 ")",rawValue);
   }
 
   return std::string(buffer);
 }
 
-std::string BUTool::RegisterHelperIO::ConvertHexNumberToString(std::string const & reg){
-  // Helper function to convert uint32_t to string in hex format
-  
-  // Read 32-bit value from register
-  uint32_t regValue = ReadRegister(reg);
+std::string BUTool::RegisterHelperIO::ConvertHexNumberToString(uint64_t rawValue){
+  // Helper function to convert uint64_t to string in hex format
 
   // Write the value into a buffer in hex-format,
   // return it as a C++ string
@@ -288,7 +282,7 @@ std::string BUTool::RegisterHelperIO::ConvertHexNumberToString(std::string const
   char buffer[bufferSize+1];
   buffer[bufferSize] = '\0';
 
-  snprintf(buffer, bufferSize, "0x%" PRIX64, uint64_t(regValue));
+  snprintf(buffer, bufferSize, "0x%" PRIX64, rawValue);
 
   return std::string(buffer);
 }

--- a/src/RegisterHelper/RegisterHelperIO_converts.cc
+++ b/src/RegisterHelper/RegisterHelperIO_converts.cc
@@ -275,3 +275,20 @@ std::string BUTool::RegisterHelperIO::ConvertEnumToString(std::string const & re
 
   return std::string(buffer);
 }
+
+std::string BUTool::RegisterHelperIO::ConvertHexNumberToString(std::string const & reg){
+  // Helper function to convert uint32_t to string in hex format
+  
+  // Read 32-bit value from register
+  uint32_t regValue = ReadRegister(reg);
+
+  // Write the value into a buffer in hex-format,
+  // return it as a C++ string
+  const int bufferSize = 20;
+  char buffer[bufferSize+1];
+  buffer[bufferSize] = '\0';
+
+  snprintf(buffer, bufferSize, "0x%" PRIX64, regValue);
+
+  return std::string(buffer);
+}

--- a/src/StatusDisplay/StatusDisplay.cc
+++ b/src/StatusDisplay/StatusDisplay.cc
@@ -232,8 +232,6 @@ namespace BUTool{
         continue;
       } catch(BUException::BAD_VALUE & e) {
         continue;
-      } catch(BUException::BAD_REG_NAME & e) {
-        continue;
       }
     }
   }

--- a/src/StatusDisplay/StatusDisplay.cc
+++ b/src/StatusDisplay/StatusDisplay.cc
@@ -232,6 +232,8 @@ namespace BUTool{
         continue;
       } catch(BUException::BAD_VALUE & e) {
         continue;
+      } catch(BUException::BAD_REG_NAME & e) {
+        continue;
       }
     }
   }

--- a/src/StatusDisplay/StatusDisplay.cc
+++ b/src/StatusDisplay/StatusDisplay.cc
@@ -217,32 +217,21 @@ namespace BUTool{
         itName != Names.end();
         itName++){
 
-      // Look for a "Status" parameter
-      // If there is no such parameter, skip the register
-      std::string status;
       try {
-        status = regIO->GetRegParameterValue(*itName, "Status");
-      } catch (BUException::BAD_REG_NAME & e) {
-        continue;
-      }
-      
-      // Check for a table name
-      std::string tableName;
-      try {
-        tableName = regIO->GetRegParameterValue(*itName, "Table");
-      } catch (BUException::BAD_REG_NAME & e) {
-        continue;
-      }
-      // Add this Address to our Tables if it matches our singleTable option, or we are looking at all tables
-      if( singleTable.empty() || TableNameCompare(tableName,singleTable)){
-        // Add the register to the given table, with a pointer to a RegHelperIO
-        // class to read values later.
-        // If we encounter a BUS_ERROR since we cannot read the register, skip that register.
-        try {
+        // Look for parameters: "Status", "Table"
+        // If one or more of these parameters do not exist, skip this register
+        std::string status = regIO->GetRegParameterValue(*itName, "Status");
+        std::string tableName = regIO->GetRegParameterValue(*itName, "Table");
+        
+        // If this cell is in the table we're looking for, add it to the
+        // relevant StatusDisplayMatrix instance
+        if( singleTable.empty() || TableNameCompare(tableName,singleTable)){
           tables[tableName].Add(*itName, regIO);
-        } catch (BUException::BUS_ERROR & e) {
-          continue;
         }
+      } catch(BUException::BUS_ERROR & e) {
+        continue;
+      } catch(BUException::BAD_VALUE & e) {
+        continue;
       }
     }
   }

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -213,6 +213,9 @@ namespace BUTool{
           if ((fabs(value) > 10000) || (fabs(value) < 0.001)) {
             snprintf(buffer,bufferSize,"%3.2e",value);
           }
+          else {
+            snprintf(buffer,bufferSize,"%3.2f",value);
+          }
         }
         else if (iequals(format,std::string("linear11"))) {
           snprintf(buffer,bufferSize,"%3.3f",value);  

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -56,9 +56,20 @@ namespace BUTool{
 
     // Using the RegisterHelperIO pointer, retrieve data about this register
     std::string _description = regIO->GetRegDescription(_address);
-    std::string _format      = GetRegParameterValueWithDefault(_address, "Format", STATUS_DISPLAY_DEFAULT_FORMAT);
-    std::string _statusLevel = GetRegParameterValueWithDefault(_address, "Status", std::string());
-    std::string _rule        = GetRegParameterValueWithDefault(_address, "Show",   std::string());
+    std::string _format;
+    try {
+      _format = regIO->GetRegParameterValue(_address, "Format");
+    } catch (BUException::BAD_VALUE & e) { _format = STATUS_DISPLAY_DEFAULT_FORMAT; }
+
+    std::string _statusLevel;
+    try {
+      _statusLevel = regIO->GetRegParameterValue(_address, "Status");
+    } catch (BUException::BAD_VALUE & e) { _statusLevel = std::string(); }
+
+    std::string _rule;
+    try {
+      _rule = regIO->GetRegParameterValue(_address, "Show");
+    } catch (BUException::BAD_VALUE & e) { _rule = std::string(); }
     boost::to_upper(_rule);
 
     convertType = regIO->GetConvertType(_address);
@@ -94,22 +105,6 @@ namespace BUTool{
   {
     word.push_back(value);
     wordShift.push_back(bitShift);
-  }
-
-  std::string GetRegParameterValueWithDefault(std::string const & reg, std::string const & name,
-                                                std::string const & defaultValue){
-    /*
-    Try to read the parameter (specified by "name") of the register (specified by "reg").
-    If the function cannot find such a parameter specified in the address table,
-    it will return the default value instead.
-    */
-    std::string result;
-    try {
-      result = regIO->GetRegParameterValue(reg, name);
-    } catch (BUException::BAD_VALUE & e) {
-      result = defaultValue;
-    }
-    return result;
   }
 
   int StatusDisplayCell::DisplayLevel() const {return statusLevel;}

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -191,7 +191,7 @@ namespace BUTool{
     return val;
   }
 
-  void StatusDisplayCell::FormatHexString(char const & buffer, int width = -1) const {
+  void StatusDisplayCell::FormatHexString(char const & buffer, int bufferSize, int width = -1) const {
     /*
     Wrapper function to format a hex string for a register, and write it
     to the given buffer. The buffer will be modified in place.
@@ -241,7 +241,7 @@ namespace BUTool{
 
         // Special hex formatting for format='x' or format='X'
         if (iequals(format, std::string("x"))) { 
-          FormatHexString(buffer, width); 
+          FormatHexString(buffer, bufferSize, width); 
         }
         
         // For other types, just write the value as a C-string to the buffer

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -191,7 +191,7 @@ namespace BUTool{
     return val;
   }
 
-  void StatusDisplayCell::FormatHexString(char * buffer, int bufferSize, int width = -1) const {
+  void StatusDisplayCell::FormatHexString(char * buffer, int bufferSize, int width) const {
     /*
     Wrapper function to format a hex string for a register, and write it
     to the given buffer. The buffer will be modified in place.

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -56,9 +56,9 @@ namespace BUTool{
 
     // Using the RegisterHelperIO pointer, retrieve data about this register
     std::string _description = regIO->GetRegDescription(_address);
-    std::string _format      = regIO->GetRegParameterValueWithDefault(_address, "Format", STATUS_DISPLAY_DEFAULT_FORMAT);
-    std::string _statusLevel = regIO->GetRegParameterValueWithDefault(_address, "Status", std::string());
-    std::string _rule        = regIO->GetRegParameterValueWithDefault(_address, "Show",   std::string());
+    std::string _format      = GetRegParameterValueWithDefault(_address, "Format", STATUS_DISPLAY_DEFAULT_FORMAT);
+    std::string _statusLevel = GetRegParameterValueWithDefault(_address, "Status", std::string());
+    std::string _rule        = GetRegParameterValueWithDefault(_address, "Show",   std::string());
     boost::to_upper(_rule);
 
     convertType = regIO->GetConvertType(_address);
@@ -94,6 +94,22 @@ namespace BUTool{
   {
     word.push_back(value);
     wordShift.push_back(bitShift);
+  }
+
+  std::string GetRegParameterValueWithDefault(std::string const & reg, std::string const & name,
+                                                std::string const & defaultValue){
+    /*
+    Try to read the parameter (specified by "name") of the register (specified by "reg").
+    If the function cannot find such a parameter specified in the address table,
+    it will return the default value instead.
+    */
+    std::string result;
+    try {
+      result = regIO->GetRegParameterValue(reg, name);
+    } catch (BUException::BAD_VALUE & e) {
+      result = defaultValue;
+    }
+    return result;
   }
 
   int StatusDisplayCell::DisplayLevel() const {return statusLevel;}

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -41,7 +41,7 @@ namespace BUTool{
   void StatusDisplayCell::Setup(RegisterHelperIO * _regIO,
       std::string const & _address,  // Stripped of Hi/Lo
 		  std::string const & _row, // Stripped of Hi/Lo
-		  std::string const & _col, // Stripped of Hi/Lo
+		  std::string const & _col  // Stripped of Hi/Lo
       )
   {
     /*

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -222,7 +222,7 @@ namespace BUTool{
     }
   }
 
-  void StatusDisplayCell::ReadAndFormatDouble(char * buffer, int bufferSize, int width) const {
+  void StatusDisplayCell::ReadAndFormatDouble(char * buffer, int bufferSize, int /* width */) const {
     /*
     Wrapper function to read and properly format a double value from the register.
     The formatted double value will be written to the buffer in-place.

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -244,7 +244,7 @@ namespace BUTool{
       case RegisterHelperIO::NONE:
       default:
       {
-        unsigned int value;
+        uint64_t value;
         regIO->ReadConvert(address, value);
         // If we are specifying the width, add a *
         if (width >= 0) {

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -176,7 +176,7 @@ namespace BUTool{
 
         // Hex formatting for format='x' or format='X'
         if (iequals(format, std::string("x"))) {
-          uint64_t val = uint64_t(value);
+          uint32_t val = regIO->ReadRegister(address);
           if (val >= 10) {
             fmtString.assign("0x%");
             if (width >= 0) {

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -290,6 +290,9 @@ namespace BUTool{
     regIO->ReadConvert(address, value);
 
     // Do the formatting and write to the buffer
+    // Build the format string for snprintf
+    std::string fmtString("%");
+
     // If we are specifying the width, add a *
     if (width >= 0) {
       fmtString.append("*");
@@ -309,9 +312,6 @@ namespace BUTool{
     char buffer[bufferSize+1];  //64bit integer can be max 20 ascii chars (as a signed int)
     memset(buffer,' ',20);
     buffer[bufferSize] = '\0';
-
-    //Build the format string for snprintf
-    std::string fmtString("%");
 
     // Read+write values to the buffer based on the convert type for this register
     switch(convertType) {

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -224,7 +224,7 @@ namespace BUTool{
       }
       case RegisterHelperIO::INT:
       {
-        int value;
+        int64_t value;
         regIO->ReadConvert(address, value);
         // If we are specifying the width, add a *
         if (width >= 0) {

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -277,7 +277,7 @@ namespace BUTool{
     }
   }
 
-  void StatusDisplayCell::ReadAndFormatInt(char * buffer, int bufferSize, int width) const {
+  void StatusDisplayCell::ReadAndFormatUInt(char * buffer, int bufferSize, int width) const {
     /*
     Wrapper function to read and format an unsigned integer value.
     The formatted unsigned integer value will be written to the buffer in-place.

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -250,6 +250,59 @@ namespace BUTool{
     }
   }
 
+  void StatusDisplayCell::ReadAndFormatInt(char * buffer, int bufferSize, int width) const {
+    /*
+    Wrapper function to read and format an integer value.
+    The formatted integer value will be written to the buffer in-place.
+    
+    Please note that we're explicitly using 64-bit integers to avoid confusion.
+    */
+    
+    // Retrieve the value
+    int64_t value;
+    regIO->ReadConvert(address, value);
+    
+    // Do the formatting and write to the buffer
+    // If we are specifying the width, add a *
+    if (width >= 0) {
+      fmtString.append("*");
+    }
+    fmtString.append(PRId64);
+
+    if (width == -1) {
+      snprintf(buffer, bufferSize, fmtString.c_str(), value);
+    }
+    else {
+      snprintf(buffer, bufferSize, fmtString.c_str(), width, value);
+    }
+  }
+
+  void StatusDisplayCell::ReadAndFormatInt(char * buffer, int bufferSize, int width) const {
+    /*
+    Wrapper function to read and format an unsigned integer value.
+    The formatted unsigned integer value will be written to the buffer in-place.
+
+    Please note that we're explicitly using 64-bit unsigned integers to avoid confusion.
+    */
+
+    // Retrieve the value
+    uint64_t value;
+    regIO->ReadConvert(address, value);
+
+    // Do the formatting and write to the buffer
+    // If we are specifying the width, add a *
+    if (width >= 0) {
+      fmtString.append("*");
+    }
+    fmtString.append(PRIu64);
+    if (width == -1) {
+      snprintf(buffer, bufferSize, fmtString.c_str(), value);
+    }
+    else {
+      snprintf(buffer, bufferSize, fmtString.c_str(), width, value);
+    }
+  }
+
   std::string StatusDisplayCell::Print(int width = -1,bool /*html*/) const
   { 
     const int bufferSize = 20;
@@ -284,39 +337,14 @@ namespace BUTool{
       }
       case RegisterHelperIO::INT:
       {
-        int64_t value;
-        regIO->ReadConvert(address, value);
-        // If we are specifying the width, add a *
-        if (width >= 0) {
-          fmtString.append("*");
-        }
-        fmtString.append(PRId64);
-
-        if (width == -1) {
-          snprintf(buffer, bufferSize, fmtString.c_str(), value);
-        }
-        else {
-          snprintf(buffer, bufferSize, fmtString.c_str(), width, value);
-        }
+        ReadAndFormatInt(buffer, bufferSize, width);
         break;
       }
       case RegisterHelperIO::UINT:
       case RegisterHelperIO::NONE:
       default:
       {
-        uint64_t value;
-        regIO->ReadConvert(address, value);
-        // If we are specifying the width, add a *
-        if (width >= 0) {
-          fmtString.append("*");
-        }
-        fmtString.append(PRIu64);
-        if (width == -1) {
-          snprintf(buffer, bufferSize, fmtString.c_str(), value);
-        }
-        else {
-          snprintf(buffer, bufferSize, fmtString.c_str(), width, value);
-        }
+        ReadAndFormatUInt(buffer, bufferSize, width);
         break;
       }
     }

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -241,7 +241,7 @@ namespace BUTool{
 
         // Special hex formatting for format='x' or format='X'
         if (iequals(format, std::string("x"))) { 
-          FormatHexString(width, buffer); 
+          FormatHexString(buffer, width); 
         }
         
         // For other types, just write the value as a C-string to the buffer

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -222,7 +222,7 @@ namespace BUTool{
     }
   }
 
-  void StatusDisplayCell::ReadAndFormatDouble(char * buffer, int bufferSize, int width) {
+  void StatusDisplayCell::ReadAndFormatDouble(char * buffer, int bufferSize, int width) const {
     /*
     Wrapper function to read and properly format a double value from the register.
     The formatted double value will be written to the buffer in-place.

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -191,7 +191,7 @@ namespace BUTool{
     return val;
   }
 
-  void StatusDisplayCell::FormatHexString(char const & buffer, int bufferSize, int width = -1) const {
+  void StatusDisplayCell::FormatHexString(char * buffer, int bufferSize, int width = -1) const {
     /*
     Wrapper function to format a hex string for a register, and write it
     to the given buffer. The buffer will be modified in place.

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -235,7 +235,7 @@ namespace BUTool{
     // Do the formatting and write to the buffer
     if (iequals(format, std::string("fp16"))) {
       // If the double value is very large or very small, use scientific notation
-      if ((fabs(value) > 10000) || (fabs(value) < 0.001)) {
+      if ( ((fabs(value) > 10000) || (fabs(value) < 0.001)) && (value != 0) ) {
         snprintf(buffer,bufferSize,"%3.2e",value);
       }
       else {
@@ -344,11 +344,15 @@ namespace BUTool{
         break;
       }
       case RegisterHelperIO::UINT:
-      case RegisterHelperIO::NONE:
-      default:
       {
         ReadAndFormatUInt(buffer, bufferSize, width);
         break;
+      }
+      // Default is HEX format for StatusDisplay 
+      case RegisterHelperIO::NONE:
+      default:
+      {
+        ReadAndFormatHexString(buffer, bufferSize, width); 
       }
     }
     return std::string(buffer);

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -200,7 +200,7 @@ namespace BUTool{
           }
         }
         else {
-          snprintf(buffer,bufferSize,"%s",value);
+          snprintf(buffer,bufferSize,"%s",value.c_str());
         }
         break;
       }

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -112,7 +112,7 @@ namespace BUTool{
   bool StatusDisplayCell::SuppressRow( bool force) const
   {
     // Compute the full value for this entry
-    uint64_t val = ComputeValue();
+    uint64_t val = regIO->ComputeValueFromRegister(address);
     bool suppressRow = (iequals( displayRule, "nzr") && (val == 0)) && !force;
     return suppressRow;
   }
@@ -130,7 +130,7 @@ namespace BUTool{
   bool StatusDisplayCell::Display(int level,bool force) const
   {
     // Compute the full value for this entry
-    uint64_t val = ComputeValue();
+    uint64_t val = regIO->ComputeValueFromRegister(address);
 
     // Decide if we should display this cell
     bool display = (level >= statusLevel) && (statusLevel != 0);

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -263,6 +263,9 @@ namespace BUTool{
     regIO->ReadConvert(address, value);
     
     // Do the formatting and write to the buffer
+    // Build the format string for snprintf
+    std::string fmtString("%");
+    
     // If we are specifying the width, add a *
     if (width >= 0) {
       fmtString.append("*");

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -103,20 +103,9 @@ namespace BUTool{
     // Setup the StatusDisplayCell instance for this register
     ptrCell->Setup(regIO,registerName,row,col);
 
-    // Read the value if it is as non-zero status level
-    // A status level of zero is for write only registers
-    // if(ptrCell->DisplayLevel() > 0){
-    //   uint32_t value;
-    //   value = regIO->ReadRegister(registerName);
-    //   ptrCell->Fill(value,bitShift);
-    // }
-    //Setup should have thrown if something bad happened, so we are safe to update the search maps
+    // Setup should have thrown if something bad happened, so we are safe to update the search maps
     rowColMap[row][col] = ptrCell;
     colRowMap[col][row] = ptrCell;
-
-    uint32_t valueMask = regIO->GetRegMask(registerName); 
-    ptrCell->SetMask(valueMask);
-
   }
 
   void StatusDisplayMatrix::CheckName(std::string const & newTableName)

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -103,7 +103,6 @@ namespace BUTool{
     }
 
     // Check if registerName contains a "_HI" or a "_LO"
-    // TODO: Can possibly remove this block if we're not going to display such registers anyway
     if((registerName.find("_LO") == (registerName.size()-3)) ||
        (registerName.find("_HI") == (registerName.size()-3))) {
       // Search for an existing base register name

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -415,7 +415,7 @@ namespace BUTool{
       parsedName.push_back(*itTok); // for _N
     }
     
-    #ifdef BUILD_UPDATED_ROW_COL_NAMES
+    #ifdef SD_USE_NEW_PARSER
     return BuildNameWithMultipleUnderscores(markup, parsedName);
     #endif
 

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -82,16 +82,7 @@ namespace BUTool{
   // Add the register with registerName into a StatusDisplayMatrix table instance.
   {
     // Find the table name for this register. If we can't find one, throw an exception
-    std::string tableName;
-    try{
-      tableName = regIO->GetRegParameterValue(registerName, "Table");
-    }catch (BUException::BAD_REG_NAME & e){
-      BUException::BAD_VALUE e2;
-      char tmp[256];
-      snprintf(tmp, 255, "Missing Table value for %s \n",registerName.c_str());
-      e2.Append(tmp);
-      throw e2;
-    }
+    std::string tableName = regIO->GetRegParameterValue(registerName, "Table");
     
     CheckName(NameBuilder(tableName,registerName));
 
@@ -154,21 +145,21 @@ namespace BUTool{
     std::string statusLevel;
     try {
       statusLevel = regIO->GetRegParameterValue(registerName, "Status");
-    } catch (BUException::BAD_REG_NAME & e) {
+    } catch (BUException::BAD_VALUE & e) {
       statusLevel = std::string("");
     }
     
     std::string rule;
     try {
       rule = regIO->GetRegParameterValue(registerName, "Show");
-    } catch (BUException::BAD_REG_NAME & e) {
+    } catch (BUException::BAD_VALUE & e) {
       rule = std::string("");
     }
     
     std::string format;
     try {
       format = regIO->GetRegParameterValue(registerName, "Format");
-    } catch (BUException::BAD_REG_NAME & e) {
+    } catch (BUException::BAD_VALUE & e) {
       format = STATUS_DISPLAY_DEFAULT_FORMAT;
     }
 
@@ -179,7 +170,7 @@ namespace BUTool{
     try {
       // True if string isn't equal to "0"
       enabled=regIO->GetRegParameterValue(registerName, "Enabled").compare("0");
-    } catch (BUException::BAD_REG_NAME & e) {
+    } catch (BUException::BAD_VALUE & e) {
       enabled=true;
     }
  
@@ -355,7 +346,7 @@ namespace BUTool{
     std::string newName;
     try {
       newName = regIO->GetRegParameterValue(addressBase, parameterName);
-    } catch (BUException::BAD_REG_NAME & e) {
+    } catch (BUException::BAD_VALUE & e) {
       // Missing row or column
       BUException::BAD_VALUE e;
       std::string error("Missing ");

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -271,19 +271,22 @@ namespace BUTool{
       
       // Check if this is a special parse character
       // If it is, we'll check the number next to it to determine the position
-      if (markup[iChar] == STATUS_DISPLAY_PARAMETER_PARSE_TOKEN) {
+      if ((markup[iChar] == STATUS_DISPLAY_PARAMETER_PARSE_TOKEN) && (iChar == 0)) {
         // We must have an integer right after the parse token, if not, raise an exception
         const bool validMarkup = (iChar + 1 < markup.size()) && (isdigit(markup[iChar+1]));
         if (!validMarkup) {
           BUException::BAD_VALUE e;	    
           std::string error("Bad markup name for ");
-          error += name + " with token " + std::to_string(pos) + " from markup " + markup;
+          error += name; 
           e.Append(error.c_str());
           throw e;
         }
 
         // Read the integer to determine the position
-        int position = std::stoi(markup[iChar+1]);
+        std::string positionStr;
+        positionStr.push_back(markup[iChar+1]);
+        
+        int position = std::stoi(positionStr);
         // Build the parsed vector of position names if we haven't
         if(positionNames.size() == 0) {
           positionNames.push_back(name); // for _0
@@ -297,10 +300,12 @@ namespace BUTool{
           result += " ";
         }
         result.append(positionNames[position]);
+        // Do not process the next character again
+        iChar++;
       }
       // Normal character, just add to the resulting name
       else {
-        result.append(markup[iChar]);
+        result.push_back(markup[iChar]);
       }
     }
     return result;

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -78,11 +78,9 @@ namespace BUTool{
     return rowColMap.at(row).at(col);
   }
 
-  void StatusDisplayMatrix::Add(std::string registerName, RegisterHelperIO* regIO)
+  void StatusDisplayMatrix::Add(std::string registerName, RegisterHelperIO* regIO, uMap const & parameters)
   // Add the register with registerName into a StatusDisplayMatrix table instance.
   {
-    uMap parameters = dynamic_cast<IPBusIO*>(regIO)->GetParameters(registerName);
-
     // Find the table name for this register. If we can't find one, throw an exception
     uMap::const_iterator itTable = parameters.find("Table");
     if(itTable == parameters.end()) {

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -92,7 +92,18 @@ namespace BUTool{
 
     int bitShift = 0;
 
-    // Check if registerName contains a "_HI" or a "_LO"    
+    // Check if registerName ends with a "_HI" or a "_LO"    
+    // Skip such registers for now because we can't handle them
+    if((registerName.find("_LO") == (registerName.size()-3)) ||
+       (registerName.find("_HI") == (registerName.size()-3))) {
+        BUException::BAD_REG_NAME e;
+        e.Append("Register name: ");
+        e.Append(registerName);
+        throw e;
+    }
+
+    // Check if registerName contains a "_HI" or a "_LO"
+    // TODO: Can possibly remove this block if we're not going to display such registers anyway
     if((registerName.find("_LO") == (registerName.size()-3)) ||
        (registerName.find("_HI") == (registerName.size()-3))) {
       // Search for an existing base register name
@@ -146,14 +157,14 @@ namespace BUTool{
     try {
       statusLevel = regIO->GetRegParameterValue(registerName, "Status");
     } catch (BUException::BAD_VALUE & e) {
-      statusLevel = std::string("");
+      statusLevel = std::string();
     }
     
     std::string rule;
     try {
       rule = regIO->GetRegParameterValue(registerName, "Show");
     } catch (BUException::BAD_VALUE & e) {
-      rule = std::string("");
+      rule = std::string();
     }
     
     std::string format;
@@ -183,7 +194,7 @@ namespace BUTool{
     else {
       ptrCell = cell[registerName];
     }
-    ptrCell->Setup(registerName,description,row,col,format,rule,statusLevel,enabled);
+    ptrCell->Setup(regIO,registerName,description,row,col,format,rule,statusLevel,enabled);
     // Read the value if it is as non-zero status level
     // A status level of zero is for write only registers
     if(ptrCell->DisplayLevel() > 0){

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -105,11 +105,11 @@ namespace BUTool{
 
     // Read the value if it is as non-zero status level
     // A status level of zero is for write only registers
-    if(ptrCell->DisplayLevel() > 0){
-      uint32_t value;
-      value = regIO->ReadRegister(registerName);
-      ptrCell->Fill(value,bitShift);
-    }
+    // if(ptrCell->DisplayLevel() > 0){
+    //   uint32_t value;
+    //   value = regIO->ReadRegister(registerName);
+    //   ptrCell->Fill(value,bitShift);
+    // }
     //Setup should have thrown if something bad happened, so we are safe to update the search maps
     rowColMap[row][col] = ptrCell;
     colRowMap[col][row] = ptrCell;

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -148,13 +148,8 @@ namespace BUTool{
       }
     }
 
-    // Get description,format,rule, and statuslevel
-    std::string description;
-    try {
-      description = regIO->GetRegParameterValue(registerName, "Description");
-    } catch (BUException::BAD_REG_NAME & e) {
-      description = std::string("");
-    }
+    // Get description, format, rule, and status level
+    std::string description = regIO->GetRegDescription(registerName);
     
     std::string statusLevel;
     try {

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -250,16 +250,16 @@ namespace BUTool{
     }
   }
 
-  void StatusDisplayMatrix::CheckForInvalidCharacter(std::string const & name, std::string const & invalidChar) const{
+  void StatusDisplayMatrix::CheckForInvalidCharacter(std::string const & name, char const & invalidChar) const{
     /*
     Function to check if there is an invalid character in the given string
     Throws a BUException if there is one.
     */
     for (size_t iChar = 0; iChar < name.size(); iChar++) {
-      if (markup[iChar] == invalidChar) {
+      if (name[iChar] == invalidChar) {
         BUException::BAD_VALUE e;	    
         std::string error("Spaces are not allowed in markup ");
-        error += markup;
+        error += name;
         e.Append(error.c_str());
         throw e;
       } 

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -150,41 +150,6 @@ namespace BUTool{
       }
     }
 
-    // Get description, format, rule, and status level
-    std::string description = regIO->GetRegDescription(registerName);
-    
-    std::string statusLevel;
-    try {
-      statusLevel = regIO->GetRegParameterValue(registerName, "Status");
-    } catch (BUException::BAD_VALUE & e) {
-      statusLevel = std::string();
-    }
-    
-    std::string rule;
-    try {
-      rule = regIO->GetRegParameterValue(registerName, "Show");
-    } catch (BUException::BAD_VALUE & e) {
-      rule = std::string();
-    }
-    
-    std::string format;
-    try {
-      format = regIO->GetRegParameterValue(registerName, "Format");
-    } catch (BUException::BAD_VALUE & e) {
-      format = STATUS_DISPLAY_DEFAULT_FORMAT;
-    }
-
-    boost::to_upper(rule);
-
-    // Determine if this register is "enabled" to be shown
-    bool enabled=true;
-    try {
-      // True if string isn't equal to "0"
-      enabled=regIO->GetRegParameterValue(registerName, "Enabled").compare("0");
-    } catch (BUException::BAD_VALUE & e) {
-      enabled=true;
-    }
- 
     StatusDisplayCell * ptrCell;
     // Add or append this entry
     if(cell.find(registerName) == cell.end()) {
@@ -194,7 +159,9 @@ namespace BUTool{
     else {
       ptrCell = cell[registerName];
     }
-    ptrCell->Setup(regIO,registerName,description,row,col,format,rule,statusLevel,enabled);
+    // Setup the StatusDisplayCell instance for this register
+    ptrCell->Setup(regIO,registerName,row,col);
+
     // Read the value if it is as non-zero status level
     // A status level of zero is for write only registers
     if(ptrCell->DisplayLevel() > 0){

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -82,8 +82,9 @@ namespace BUTool{
   // Add the register with registerName into a StatusDisplayMatrix table instance.
   {
     // Find the table name for this register. If we can't find one, throw an exception
+    std::string tableName;
     try{
-      std::string tableName = regIO->GetRegParameterValue(registerName, "Table");
+      tableName = regIO->GetRegParameterValue(registerName, "Table");
     }catch (BUException::BAD_REG_NAME & e){
       BUException::BAD_VALUE e2;
       char tmp[256];
@@ -182,7 +183,7 @@ namespace BUTool{
     bool enabled=true;
     try {
       // True if string isn't equal to "0"
-      enabled=regIO->GetRegParameterValue("Enabled").compare("0");
+      enabled=regIO->GetRegParameterValue(registerName, "Enabled").compare("0");
     } catch (BUException::BAD_REG_NAME & e) {
       enabled=true;
     }
@@ -201,12 +202,7 @@ namespace BUTool{
     // A status level of zero is for write only registers
     if(ptrCell->DisplayLevel() > 0){
       uint32_t value;
-      try {
-        value = regIO->ReadRegister(registerName);
-      }
-      catch(BUException::BUS_ERROR & e) {
-        continue;
-      }
+      value = regIO->ReadRegister(registerName);
       ptrCell->Fill(value,bitShift);
     }
     //Setup should have thrown if something bad happened, so we are safe to update the search maps


### PR DESCRIPTION
This PR has code changes to update the behavior of `StatusDisplay` and it's related classes. These classes now hold a pointer to a `RegisterHelperIO` class, and all read functionality is handled by the `RegisterHelperIO` pointer.