### PR TITLE
StatusDisplay fixes

### DIFF
--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -77,6 +77,7 @@ namespace BUTool{
     std::string col;
     bool enabled;
 
+    uint32_t word;
     uint32_t mask;
     
     std::string format;

--- a/include/StatusDisplay/StatusDisplayCell.hh
+++ b/include/StatusDisplay/StatusDisplayCell.hh
@@ -52,7 +52,7 @@ namespace BUTool{
     std::string const & GetDesc() const;
     std::string const & GetAddress() const;
 
-    void ReadAndFormatHexString(char * buffer, int bufferSize, int width = -1) const;
+    // Helper formatting functions for printing values
     void ReadAndFormatDouble   (char * buffer, int bufferSize, int width = -1) const;
     void ReadAndFormatInt      (char * buffer, int bufferSize, int width = -1) const;
     void ReadAndFormatUInt     (char * buffer, int bufferSize, int width = -1) const;

--- a/src/BUTool/Launcher_commands.cc
+++ b/src/BUTool/Launcher_commands.cc
@@ -53,8 +53,10 @@ void Launcher::LoadCommandList()
   AddCommand("add_dev_ofile",&Launcher::AddDeviceOutputFile,
 	     "Place device print calls in filename.\n"\
 	     "  Usage:\n"\
-	     "  add_dev_ofile filename <device#>\n"\
-             "  If no device# listed, it will be added to all devices\n");  
+	     "  add_dev_ofile filename <device#> <printLevel>\n"\
+             "  If no device# listed, it will be added to all devices\n"\
+             "  Print level can be the following:\n"\
+             "  0: INFO, 1: DEBUG, 2: ERROR\n");  
   AddCommand("set_var",&Launcher::SetVariable,
 	     "Set an internal variable.\n"\
 	     "  Usage:\n"\
@@ -425,19 +427,34 @@ CommandReturn::status Launcher::AddDeviceOutputFile(std::vector<std::string> str
       iStartDev = iArg[1];
       iEndDev = iArg[1]+1; //Cause the following loop to end after iArg[i]
     }
-
+    
+    Level::level printLevel = Level::INFO;
+    // A print-level argument has been given.
+    if (iArg.size() > 2){
+      uint64_t printLevelInt = intArg[2];
+      switch(printLevelInt) {
+        case 0:
+          printLevel = Level::INFO;
+          break;
+        case 1:
+          printLevel = Level::DEBUG;
+          break;
+        case 2:
+          printLevel = Level::ERROR;
+          break;
+        default:
+          return CommandReturn::BAD_ARGS;
+      }
+    }
+    
+    // Loop over devices and add the output stream for each device
     for(size_t iDev = iStartDev; 
-	iDev < device.size() && iDev < iEndDev;
-	iDev++){
+      iDev < device.size() && iDev < iEndDev;
+      iDev++) {
       if(iDev < device.size()){
-	BUTextIO * text_ptr = NULL; 
-	if(
-	   (text_ptr = dynamic_cast<BUTextIO*>(device[iArg[0]])) 
-	   ){
-	  text_ptr->AddOutputStream(Level::INFO,newStream);
-	}	
-      }else{
-	Print(Level::INFO,"Error: %" PRIu64 " out of range (%zu)",iArg[0],device.size());
+        device[iDev]->AddOutputStream(printLevel, newStream);
+      } else {
+        Print(Level::INFO,"Error: %" PRIu64 " out of range (%zu)",iDev,device.size());
       }   
     } 
     return CommandReturn::OK;

--- a/src/BUTool/Launcher_commands.cc
+++ b/src/BUTool/Launcher_commands.cc
@@ -431,7 +431,7 @@ CommandReturn::status Launcher::AddDeviceOutputFile(std::vector<std::string> str
     Level::level printLevel = Level::INFO;
     // A print-level argument has been given.
     if (iArg.size() > 2){
-      uint64_t printLevelInt = intArg[2];
+      uint64_t printLevelInt = iArg[2];
       switch(printLevelInt) {
         case 0:
           printLevel = Level::INFO;

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -3,7 +3,6 @@
 #include <BUTool/ToolException.hh>
 
 #include <boost/algorithm/string/predicate.hpp> //for iequals
-#include <iostream>
 
 std::string BUTool::RegisterHelperIO::ReadString(std::string const & /*reg*/){
   //=============================================================================
@@ -218,10 +217,9 @@ void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, int64_t & va
   // Sign extend b-bit number, override the value in x
   // See here: https://graphics.stanford.edu/~seander/bithacks.html#FixedSignExtend
   int64_t x = rawVal;
-  uint64_t tmp = 1;
-  int64_t const m = tmp << (b - 1); 
+  int64_t const m = 1U << (b - 1); 
 
-  x = x & ((tmp << b) - 1);
+  x = x & ((1U << b) - 1);
   val = (x ^ m) - m;
 }
 

--- a/src/RegisterHelper/RegisterHelperIO.cc
+++ b/src/RegisterHelper/RegisterHelperIO.cc
@@ -3,6 +3,7 @@
 #include <BUTool/ToolException.hh>
 
 #include <boost/algorithm/string/predicate.hpp> //for iequals
+#include <iostream>
 
 std::string BUTool::RegisterHelperIO::ReadString(std::string const & /*reg*/){
   //=============================================================================
@@ -217,9 +218,10 @@ void BUTool::RegisterHelperIO::ReadConvert(std::string const & reg, int64_t & va
   // Sign extend b-bit number, override the value in x
   // See here: https://graphics.stanford.edu/~seander/bithacks.html#FixedSignExtend
   int64_t x = rawVal;
-  int64_t const m = 1U << (b - 1); 
+  uint64_t tmp = 1;
+  int64_t const m = tmp << (b - 1); 
 
-  x = x & ((1U << b) - 1);
+  x = x & ((tmp << b) - 1);
   val = (x ^ m) - m;
 }
 

--- a/src/RegisterHelper/RegisterHelperIO_converts.cc
+++ b/src/RegisterHelper/RegisterHelperIO_converts.cc
@@ -39,7 +39,8 @@ BUTool::RegisterHelperIO::ConvertType BUTool::RegisterHelperIO::GetConvertType(s
     std::string format = formatVal->second;
     if(format.size() > 0) {
       // String data type
-      if (( iequals(format, "T")) ||
+      if (( format[0] == 't') ||
+          ( format[0] == 'T') ||
           ( iequals(format, "IP") )) 
       {
         ret = STRING;

--- a/src/RegisterHelper/RegisterHelperIO_converts.cc
+++ b/src/RegisterHelper/RegisterHelperIO_converts.cc
@@ -13,10 +13,14 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+using boost::algorithm::iequals;
+
+#define DEFAULT_FORMAT "X"
+
 std::string BUTool::RegisterHelperIO::GetConvertFormat(std::string const & reg){
   // From a given node address, retrieve the "Format" parameter of the node
   auto parameter = GetRegParameters(reg);
-  std::string format("none");
+  std::string format(DEFAULT_FORMAT);
   auto formatVal = parameter.find("Format");
   if(formatVal != parameter.end()){
     format = formatVal->second;
@@ -33,25 +37,28 @@ BUTool::RegisterHelperIO::ConvertType BUTool::RegisterHelperIO::GetConvertType(s
   //Search for Format
   if(formatVal != parameter.end()){
     std::string format = formatVal->second;
-    if(format.size() > 0){
-      if (( format[0] == 'T') ||
-	  ( format[0] == 't') ||
-	  ( boost::algorithm::iequals(format, std::string("IP")) ) ||
-	  ( boost::algorithm::iequals(format, "X")) ) {
-	ret = STRING;
+    if(format.size() > 0) {
+      // String data type
+      if (( iequals(format, "T")) ||
+          ( iequals(format, "IP") )) 
+      {
+        ret = STRING;
       }
-      if ((format[0] == 'M') |
-	  (format[0] == 'm') |
-	  (format == "fp16")) {
-	ret = FP;
+      // Floating point values
+      else if ((format[0] == 'M') ||
+          (format[0] == 'm') ||
+          (format == "fp16")) {
+        ret = FP;
       }
-      if ((format.size() == 1) &&
-	  (format[0] == 'd')) {
-	ret = INT;
+      // Signed integer data type
+      else if ((format.size() == 1) &&
+          (format[0] == 'd')) {
+        ret = INT;
       }
-      if ((format.size() == 1) &&
-	  (format[0] == 'u')) {
-	ret = UINT;
+      // Unsigned integer, can be in hex format as well if format='X' is specified
+      else if ((format.size() == 1) &&
+          ( (format[0] == 'u') || (iequals(format, "X")) ) ) {
+        ret = UINT;
       }
     }
   }

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -153,7 +153,7 @@ namespace BUTool{
     
     // Read the 32-bit value from the register and convert to 64-bit value
     // so that it's ready for printing
-    uint64_t val = regIO->ReadRegister(address);
+    uint64_t val = regIO->ComputeValueFromRegister(address);
 
     // Now, do the formatting
     std::string fmtString = "%";

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -163,12 +163,20 @@ namespace BUTool{
         width -= 2;
       }
     }
+
+    // Zero padding or space padding, depending on the format
     if (width >= 0) {
-      fmtString.append("*");
+      if (iequals(format, "x")) {
+        fmtString.append("0*");
+      }
+      else {
+        fmtString.append("*");
+      }
     }
-    
+
+    // PRI macro to print 64-bit hex value    
     fmtString.append(PRIX64);
-    
+
     if (width == -1) {
       snprintf(buffer, bufferSize, fmtString.c_str(), val);
     }

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -231,7 +231,7 @@ namespace BUTool{
 
     // Zero padding or space padding, depending on the format
     if (width >= 0) {
-      if (iequals(format, "x")) {
+      if (iequals(format, "x") && (value >= 10)) {
         fmtString.append("0*");
       }
       else {

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -149,8 +149,9 @@ namespace BUTool{
     to the given buffer. The buffer will be modified in place.
     */
     
-    // Read the 32-bit value from the register
-    uint32_t val = regIO->ReadRegister(address);
+    // Read the 32-bit value from the register and convert to 64-bit value
+    // so that it's ready for printing
+    uint64_t val = regIO->ReadRegister(address);
 
     // Now, do the formatting
     std::string fmtString = "%";

--- a/src/StatusDisplay/StatusDisplayCell.cc
+++ b/src/StatusDisplay/StatusDisplayCell.cc
@@ -222,7 +222,7 @@ namespace BUTool{
     std::string fmtString("%");
 
     // Update the format string for hex-displays
-    if ((val >= 10) && (iequals(format, "X"))) {
+    if ((value >= 10) && (iequals(format, "X"))) {
       fmtString.assign("0x%");
       if (width >= 0) {
         width -= 2;
@@ -233,12 +233,18 @@ namespace BUTool{
     if (width >= 0) {
       if (iequals(format, "x")) {
         fmtString.append("0*");
-        fmtString.append(PRIX64);
       }
       else {
         fmtString.append("*");
-        fmtString.append(PRIu64);
       }
+    }
+   
+    // PRI macros for hex or unsigned int formatting 
+    if (iequals(format, "x")) {
+      fmtString.append(PRIX64);
+    }
+    else {
+      fmtString.append(PRIu64);
     }
 
     if (width == -1) {

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -358,6 +358,14 @@ namespace BUTool{
     // Determine the row or column name from the markup and the register name
     std::string newName = NameBuilder(markup, registerName);
 
+    // If there is a "_LO" or "_HI" in the row/column name, drop it
+    if (newName.find("_LO") == newName.size()-3) {
+      newName = newName.substr(0, newName.find("_LO"));
+    }
+    else if (newName.find("_HI") == newName.size()-3) {
+      newName = newName.substr(0, newName.find("_HI"));
+    }
+
     return newName;
   }
 


### PR DESCRIPTION
This PR has several fixes+updates on top of #33. Updates here include:

- The hex-formatting functionality is moved to the `StatusDisplayCell` function which handles formatting unsigned integer data.
- Fixes in `add_dev_ofile` command, added an additional third argument specifying the print stream.
- Fix the register merging functionality, so that 32-bit values from two separate registers can be merged into a 64-bit value and can be displayed correctly. Also discarded the "_LO" and "_HI" suffixes from the row/column names.