### PR TITLE
Update on StatusDisplay NameBuilder

### DIFF
--- a/include/BUTool/ToolException.hh
+++ b/include/BUTool/ToolException.hh
@@ -12,6 +12,7 @@ namespace BUException{
   ExceptionClassGenerator(REG_WRITE_DENIED,"Write access denied\n")
   ExceptionClassGenerator(BAD_REG_NAME,"Register name not found\n")
   ExceptionClassGenerator(BAD_VALUE,"Bad value\n")
+  ExceptionClassGenerator(BAD_MARKUP_NAME,"Bad markup name\n")
   ExceptionClassGenerator(BUS_ERROR,"Bus error encountered during a register read/write\n")
   // BUTextIO exception
   ExceptionClassGenerator(TEXTIO_BAD_INIT, "BUTool::RegisterHelper TextIO pointer is NULL\n Did you forget to call SetupTextIO() in the device's constructor?\n")

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -203,7 +203,7 @@ namespace BUTool{
         if (isdigit(markup[iChar+1])) {
           std::string positionStr;
           positionStr.push_back(markup[iChar+1]);
-          int position = std::stoi(positionStr);
+          size_t position = std::stoi(positionStr);
          
           // Add whitespace if we need it
           if (result.size() > 0) {
@@ -224,7 +224,8 @@ namespace BUTool{
 
         // Check if the next character is another underscore
         else if (markup[iChar+1] == STATUS_DISPLAY_PARAMETER_PARSE_TOKEN) {
-          result.append(STATUS_DISPLAY_PARAMETER_PARSE_TOKEN);
+          std::string parseToken(STATUS_DISPLAY_PARAMETER_PARSE_TOKEN);
+          result.append(parseToken.c_str());
         }
 
         // Any other possibility is a bad markup name

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -224,8 +224,7 @@ namespace BUTool{
 
         // Check if the next character is another underscore
         else if (markup[iChar+1] == STATUS_DISPLAY_PARAMETER_PARSE_TOKEN) {
-          std::string parseToken(STATUS_DISPLAY_PARAMETER_PARSE_TOKEN);
-          result.append(parseToken.c_str());
+          result.push_back(STATUS_DISPLAY_PARAMETER_PARSE_TOKEN);
         }
 
         // Any other possibility is a bad markup name

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -154,7 +154,7 @@ namespace BUTool{
     */
     for (size_t iChar = 0; iChar < name.size(); iChar++) {
       if (name[iChar] == invalidChar) {
-        BUException::BAD_VALUE e;	    
+        BUException::BAD_MARKUP_NAME e;	    
         std::string error("Spaces are not allowed in markup ");
         error += name;
         e.Append(error.c_str());
@@ -192,7 +192,7 @@ namespace BUTool{
       if ((markup[iChar] == STATUS_DISPLAY_PARAMETER_PARSE_TOKEN)) {
         // Check the next character, make sure that it is within range
         if (!(iChar + 1 < markup.size())) {
-          BUException::BAD_VALUE e;	    
+          BUException::BAD_MARKUP_NAME e;	    
           std::string error("Bad markup name for ");
           error += parsedName[0]; 
           e.Append(error.c_str());
@@ -213,7 +213,7 @@ namespace BUTool{
           // Position out of bounds of the parsed name size
           // In a valid markup name, this should never happen, throw BAD_VALUE
           if (!(position < parsedName.size())) {
-            BUException::BAD_VALUE e;	    
+            BUException::BAD_MARKUP_NAME e;	    
             std::string error("Bad markup name for ");
             error += parsedName[0]; 
             e.Append(error.c_str());
@@ -230,7 +230,7 @@ namespace BUTool{
 
         // Any other possibility is a bad markup name
         else {
-          BUException::BAD_VALUE e;	    
+          BUException::BAD_MARKUP_NAME e;	    
           std::string error("Bad markup name for ");
           error += parsedName[0]; 
           e.Append(error.c_str());
@@ -309,7 +309,7 @@ namespace BUTool{
               pos = parsedName.size() - pos;
             }
             if(pos > int(parsedName.size())){
-              BUException::BAD_VALUE e;	    
+              BUException::BAD_MARKUP_NAME e;	    
               std::string error("Bad markup name for ");
               error += parsedName[0] + " with token " + std::to_string(pos) + " from markup " + markup;
               e.Append(error.c_str());
@@ -321,7 +321,7 @@ namespace BUTool{
             }
             ret.append(parsedName[pos]);
           }else{
-            BUException::BAD_VALUE e;	    
+            BUException::BAD_MARKUP_NAME e;	    
             std::string error("Bad markup for ");
             error += parsedName[0] + " from markup " + markup;
             e.Append(error.c_str());

--- a/src/StatusDisplay/StatusDisplayMatrix.cc
+++ b/src/StatusDisplay/StatusDisplayMatrix.cc
@@ -210,6 +210,15 @@ namespace BUTool{
             result += " ";
           }
 
+          // Position out of bounds of the parsed name size
+          // In a valid markup name, this should never happen, throw BAD_VALUE
+          if (!(position < parsedName.size())) {
+            BUException::BAD_VALUE e;	    
+            std::string error("Bad markup name for ");
+            error += parsedName[0]; 
+            e.Append(error.c_str());
+            throw e;
+          }
           result.append(parsedName[position]);
         }
 


### PR DESCRIPTION
This PR introduces updates to the `NameBuilder` function of the `BUTool::StatusDisplay` class. The following rules are implemented for address table markups:

- A double underscore ('__') character will be treated as a literal single underscore ('_')
- An underscore followed by a digit ('_N') will be interpreted as a special token and will be processed accordingly
- Multiple such special tokens are possible in a given markup (e.g. '_N_M')!
- If a single underscore is followed by a non-digit char, it is treated as literal (e.g. 'ZYNQ_OS' -> 'ZYNQ_OS')

