### PR TITLE
Add BUTool CI feature using the DSAT plugin

### DIFF
--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: 'BU-EDF/GenericDSATDevice_plugin'
+        path: 'GenericDSATDevice_plugin'
         ref: 'develop'
         submodules: 'recursive'
     - name: Install dependencies

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install dependencies
       run: |
         echo "Starting job: $(date)"
-        apt install libboost-regex-dev build-essential zlib1g-dev libreadline-dev libboost-dev libboost-program-options-dev libncurses5-dev
+        sudo apt install libboost-regex-dev build-essential zlib1g-dev libreadline-dev libboost-dev libboost-program-options-dev libncurses5-dev
         ls -lah .
         source env.sh
     - name: Build BUTool

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -44,12 +44,14 @@ jobs:
         echo "Setting up environment with BUTOOL_PATH=${BUTOOL_PATH}"
         source env.sh ${BUTOOL_PATH}
         make
+        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
         echo "BUTOOL_PATH=${BUTOOL_PATH}" >> ${GITHUB_ENV}
     
     - name: Run StatusDisplay test
       working-directory: ./GenericDSATDevice_plugin
       run: |
         BUTOOL_PATH=${{ env.BUTOOL_PATH }}
+        LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
         ./run_BUTool_test.sh
     
     - name: Cleanup GenericDSAT plugin

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -15,16 +15,21 @@ jobs:
     - name: Checkout GenericDSAT plugin and submodules
       uses: actions/checkout@v3
       with:
-        repository: 'BU-EDF/GenericDSATDevice_plugin'
+        repository: 'alpakpinar/GenericDSATDevice_plugin'
         path: 'GenericDSATDevice_plugin'
         ref: 'develop'
         submodules: 'recursive'
     - name: Install dependencies
       run: |
-        echo "Starting job: $(date)"
-        sudo apt install libboost-regex-dev build-essential zlib1g-dev libreadline-dev libboost-dev libboost-program-options-dev libncurses5-dev
-        ls -lah .
-        source env.sh
+        sudo apt install \
+          libboost-regex-dev \
+          build-essential \
+          zlib1g-dev \
+          libreadline-dev \
+          libboost-dev \
+          libboost-program-options-dev \
+          libncurses5-dev
+    
     - name: Build BUTool
       run: make
     - name: Build GenericDSAT plugin

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -14,6 +14,9 @@ jobs:
         echo "Starting job: $(date)"
         ls -lah .
         source env.sh
+        pwd
+        ls -lah external/
+        ls -lah external/BUException/
     - name: Build BUTool
       run: make
     - name: Build GenericDSAT plugin

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -35,7 +35,11 @@ jobs:
           libncurses5-dev
     
     - name: Build BUTool
-      run: make
+      run: |
+        make
+        ls -lah lib
+        ldd lib/libBUTool.so
+        ldd lib/libBUTool_Helpers.so
     
     - name: Build GenericDSAT plugin
       working-directory: ./GenericDSATDevice_plugin

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -12,14 +12,12 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - name: Configure environment
+    - name: Install dependencies
       run: |
         echo "Starting job: $(date)"
+        apt install libboost-regex-dev build-essential zlib1g-dev libreadline-dev libboost-dev libboost-program-options-dev libncurses5-dev
         ls -lah .
         source env.sh
-        pwd
-        ls -lah external/
-        ls -lah external/BUException/
     - name: Build BUTool
       run: make
     - name: Build GenericDSAT plugin

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -35,11 +35,7 @@ jobs:
           libncurses5-dev
     
     - name: Build BUTool
-      run: |
-        make
-        ls -lah lib
-        ldd lib/libBUTool.so
-        ldd lib/libBUTool_Helpers.so
+      run: make
     
     - name: Build GenericDSAT plugin
       working-directory: ./GenericDSATDevice_plugin
@@ -53,12 +49,10 @@ jobs:
     
     - name: Run StatusDisplay test
       working-directory: ./GenericDSATDevice_plugin
+      env:
+        BUTOOL_PATH: ${{ env.BUTOOL_PATH }}
+        LD_LIBRARY_PATH: ${{ env.LD_LIBRARY_PATH }}
       run: |
-        BUTOOL_PATH=${{ env.BUTOOL_PATH }}
-        LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
-        ls -lah lib
-        ldd lib/libDSAT_GenericDSATDevice.so
-        ldd lib/libDSAT_GenericDSAT.so
         ./run_BUTool_test.sh
     
     - name: Cleanup GenericDSAT plugin

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -1,10 +1,18 @@
 name: BUTool StatusDisplay CI
 
-on: [push]
+# Control when to run the CI job
+on: 
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Build GenericDSAT plugin
       run: |
         cd GenericDSATDevice_plugin
-        BUTOOL_PATH=$(realpath ../BUTool)
+        BUTOOL_PATH=$(realpath ../)
         source env.sh ${BUTOOL_PATH}
         make
     - name: Run StatusDisplay test

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -13,14 +13,15 @@ jobs:
       with:
         submodules: recursive
     - name: Checkout GenericDSAT plugin and submodules
-      uses: actions/checkout@v3
-      with:
-        repository: 'alpakpinar/GenericDSATDevice_plugin'
-        path: 'GenericDSATDevice_plugin'
-        ref: 'develop'
-        submodules: 'recursive'
+      run: |
+        git clone --branch develop \
+          --recursive \
+          --depth 1 \
+          --shallow-submodules \
+          https://gitlab.com/BU-EDF/GenericDSATDevice_plugin.git
     - name: Install dependencies
       run: |
+        ls -lah .
         sudo apt install \
           libboost-regex-dev \
           build-essential \

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -1,0 +1,34 @@
+name: BUTool StatusDisplay CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Configure environment
+      run: |
+        echo "Starting job: $(date)"
+        ls -lah .
+        source env.sh
+    - name: Build BUTool
+      run: make
+    - name: Build GenericDSAT plugin
+      run: |
+        git clone --recursive https://gitlab.com/BU-EDF/GenericDSATDevice_plugin.git
+        cd GenericDSATDevice_plugin
+        BUTOOL_PATH=$(realpath ../BUTool)
+        source env.sh ${BUTOOL_PATH}
+        make
+    - name: Run StatusDisplay test
+      run: ./run_BUTool_test.sh
+    - name: Cleanup
+      run: |
+        make clean
+        cd ${BUTOOL_PATH}
+        make clean
+
+        

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Configure environment
       run: |
         echo "Starting job: $(date)"

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -37,31 +37,25 @@ jobs:
     - name: Build BUTool
       run: make
     
-    - name: Build GenericDSAT plugin and run StatusDisplay test
+    - name: Build GenericDSAT plugin
       working-directory: ./GenericDSATDevice_plugin
       run: |
         BUTOOL_PATH=$(realpath ../)
         echo "Setting up environment with BUTOOL_PATH=${BUTOOL_PATH}"
         source env.sh ${BUTOOL_PATH}
         make
-        echo ${LD_LIBRARY_PATH}
-        echo ${BUTOOL_PATH}
         echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
         echo "BUTOOL_PATH=${BUTOOL_PATH}" >> ${GITHUB_ENV}
+    
+    - name: Run StatusDisplay test
+      working-directory: ./GenericDSATDevice_plugin
+      run: |
+        BUTOOL_PATH=${{ env.BUTOOL_PATH }}
+        LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
         ls -lah lib
         ldd lib/libDSAT_GenericDSATDevice.so
         ldd lib/libDSAT_GenericDSAT.so
         ./run_BUTool_test.sh
-    
-    # - name: Run StatusDisplay test
-    #   working-directory: ./GenericDSATDevice_plugin
-    #   run: |
-    #     BUTOOL_PATH=${{ env.BUTOOL_PATH }}
-    #     LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
-    #     ls -lah lib
-    #     ldd lib/libDSAT_GenericDSATDevice.so
-    #     ldd lib/libDSAT_GenericDSAT.so
-    #     ./run_BUTool_test.sh
     
     - name: Cleanup GenericDSAT plugin
       working-directory: ./GenericDSATDevice_plugin

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -44,10 +44,13 @@ jobs:
         echo "Setting up environment with BUTOOL_PATH=${BUTOOL_PATH}"
         source env.sh ${BUTOOL_PATH}
         make
+        echo "BUTOOL_PATH=${BUTOOL_PATH}" >> ${GITHUB_ENV}
     
     - name: Run StatusDisplay test
       working-directory: ./GenericDSATDevice_plugin
-      run: ./run_BUTool_test.sh
+      run: |
+        BUTOOL_PATH=${{ env.BUTOOL_PATH }}
+        ./run_BUTool_test.sh
     
     - name: Cleanup GenericDSAT plugin
       working-directory: ./GenericDSATDevice_plugin

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
+    
     - name: Checkout GenericDSAT plugin and submodules
       run: |
         git clone --branch develop \
@@ -19,9 +20,11 @@ jobs:
           --depth 1 \
           --shallow-submodules \
           https://gitlab.com/BU-EDF/GenericDSATDevice_plugin.git
+    
     - name: Install dependencies
       run: |
         ls -lah .
+        echo "Home directory: ${HOME}"
         sudo apt install \
           libboost-regex-dev \
           build-essential \
@@ -33,18 +36,22 @@ jobs:
     
     - name: Build BUTool
       run: make
+    
     - name: Build GenericDSAT plugin
+      working-directory: GenericDSATDevice_plugin
       run: |
-        cd GenericDSATDevice_plugin
-        BUTOOL_PATH=$(realpath ../)
-        source env.sh ${BUTOOL_PATH}
+        source env.sh ${HOME}
         make
+    
     - name: Run StatusDisplay test
+      working-directory: GenericDSATDevice_plugin
       run: ./run_BUTool_test.sh
-    - name: Cleanup
-      run: |
-        make clean
-        cd ${BUTOOL_PATH}
-        make clean
+    
+    - name: Cleanup GenericDSAT plugin
+      working-directory: GenericDSATDevice_plugin
+      run: make clean
+
+    - name: Cleanup BUTool
+      run: make clean
 
         

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -52,6 +52,9 @@ jobs:
       run: |
         BUTOOL_PATH=${{ env.BUTOOL_PATH }}
         LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
+        ls -lah lib
+        ldd lib/libDSAT_GenericDSATDevice.so
+        ldd lib/libDSAT_GenericDSAT.so
         ./run_BUTool_test.sh
     
     - name: Cleanup GenericDSAT plugin

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         ls -lah .
-        echo "Home directory: ${HOME}"
+        echo "Working directory: ${PWD}"
         sudo apt install \
           libboost-regex-dev \
           build-essential \
@@ -38,17 +38,19 @@ jobs:
       run: make
     
     - name: Build GenericDSAT plugin
-      working-directory: GenericDSATDevice_plugin
+      working-directory: ./GenericDSATDevice_plugin
       run: |
-        source env.sh ${HOME}
+        BUTOOL_PATH=$(realpath ../)
+        echo "Setting up environment with BUTOOL_PATH=${BUTOOL_PATH}"
+        source env.sh ${BUTOOL_PATH}
         make
     
     - name: Run StatusDisplay test
-      working-directory: GenericDSATDevice_plugin
+      working-directory: ./GenericDSATDevice_plugin
       run: ./run_BUTool_test.sh
     
     - name: Cleanup GenericDSAT plugin
-      working-directory: GenericDSATDevice_plugin
+      working-directory: ./GenericDSATDevice_plugin
       run: make clean
 
     - name: Cleanup BUTool

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -8,10 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository and submodules
+    - name: Checkout BUTool repository and submodules
       uses: actions/checkout@v3
       with:
         submodules: recursive
+    - name: Checkout GenericDSAT plugin and submodules
+      uses: actions/checkout@v3
+      with:
+        repository: 'BU-EDF/GenericDSATDevice_plugin'
+        ref: 'develop'
+        submodules: 'recursive'
     - name: Install dependencies
       run: |
         echo "Starting job: $(date)"
@@ -22,7 +28,6 @@ jobs:
       run: make
     - name: Build GenericDSAT plugin
       run: |
-        git clone --recursive https://gitlab.com/BU-EDF/GenericDSATDevice_plugin.git
         cd GenericDSATDevice_plugin
         BUTOOL_PATH=$(realpath ../BUTool)
         source env.sh ${BUTOOL_PATH}

--- a/.github/workflows/butool-ci.yml
+++ b/.github/workflows/butool-ci.yml
@@ -37,25 +37,31 @@ jobs:
     - name: Build BUTool
       run: make
     
-    - name: Build GenericDSAT plugin
+    - name: Build GenericDSAT plugin and run StatusDisplay test
       working-directory: ./GenericDSATDevice_plugin
       run: |
         BUTOOL_PATH=$(realpath ../)
         echo "Setting up environment with BUTOOL_PATH=${BUTOOL_PATH}"
         source env.sh ${BUTOOL_PATH}
         make
+        echo ${LD_LIBRARY_PATH}
+        echo ${BUTOOL_PATH}
         echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
         echo "BUTOOL_PATH=${BUTOOL_PATH}" >> ${GITHUB_ENV}
-    
-    - name: Run StatusDisplay test
-      working-directory: ./GenericDSATDevice_plugin
-      run: |
-        BUTOOL_PATH=${{ env.BUTOOL_PATH }}
-        LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
         ls -lah lib
         ldd lib/libDSAT_GenericDSATDevice.so
         ldd lib/libDSAT_GenericDSAT.so
         ./run_BUTool_test.sh
+    
+    # - name: Run StatusDisplay test
+    #   working-directory: ./GenericDSATDevice_plugin
+    #   run: |
+    #     BUTOOL_PATH=${{ env.BUTOOL_PATH }}
+    #     LD_LIBRARY_PATH=${{ env.LD_LIBRARY_PATH }}
+    #     ls -lah lib
+    #     ldd lib/libDSAT_GenericDSATDevice.so
+    #     ldd lib/libDSAT_GenericDSAT.so
+    #     ./run_BUTool_test.sh
     
     - name: Cleanup GenericDSAT plugin
       working-directory: ./GenericDSATDevice_plugin

--- a/env.sh
+++ b/env.sh
@@ -3,12 +3,21 @@ export PATH=$PWD/bin/tool/:$PATH
 
 #setup LD_LIBRARY_PATHs for BUTool and any plugins
 #must be source AFTER build finishes
+
+# Add BUTool's lib/ directory to LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH
+
+# Add the plugin libraries to the LD_LIBRARY_PATH
+
 #plugin_paths=$(find $PWD/plugins/* -type d | xargs)
 plugin_paths=$(ls -1 -d $PWD/plugins/* | xargs)
-export LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH
+
 for path in $plugin_paths
 do
-    export LD_LIBRARY_PATH=$path/lib:$LD_LIBRARY_PATH
+    # Check if this is a directory
+    if [ -d $path  ]; then
+        export LD_LIBRARY_PATH=$path/lib:$LD_LIBRARY_PATH
+    fi
 done
   
 # Add BUException submodule to the LD_LIBRARY_PATH

--- a/env.sh
+++ b/env.sh
@@ -4,10 +4,13 @@ export PATH=$PWD/bin/tool/:$PATH
 #setup LD_LIBRARY_PATHs for BUTool and any plugins
 #must be source AFTER build finishes
 #plugin_paths=$(find $PWD/plugins/* -type d | xargs)
-plugin_paths=$(ls -1 -d $PWD/plugins/*/ | xargs)
+plugin_paths=$(ls -1 -d $PWD/plugins/* | xargs)
 export LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH
 for path in $plugin_paths
 do
     export LD_LIBRARY_PATH=$path/lib:$LD_LIBRARY_PATH
 done
   
+# Add BUException submodule to the LD_LIBRARY_PATH
+EXCEPTION_PATH="$PWD/external/BUException/lib"
+export LD_LIBRARY_PATH=$EXCEPTION_PATH:$LD_LIBRARY_PATH

--- a/mk/Makefile
+++ b/mk/Makefile
@@ -4,7 +4,7 @@ include mk/helpers.mk
 include mk/uhal.mk
 
 
-BUTOOL_PATH=${MAKE_PATH}
+BUTOOL_PATH=${PWD}
 CXX=g++
 RUNTIME_LDPATH?=${PWD}
 

--- a/mk/Makefile
+++ b/mk/Makefile
@@ -4,7 +4,7 @@ include mk/helpers.mk
 include mk/uhal.mk
 
 
-BUTOOL_PATH=${PWD}
+BUTOOL_PATH=${MAKE_PATH}
 CXX=g++
 RUNTIME_LDPATH?=${PWD}
 
@@ -83,7 +83,7 @@ LINK_LIBRARY_FLAGS = -shared -fPIC -Wall -Wl,--no-as-needed -g -O3 -rdynamic ${L
 LINK_EXECUTABLE_FLAGS = -Wall -Wl,--no-as-needed -g -O3 -rdynamic ${LIBRARY_PATH} ${EXECUTABLE_LIBRARIES} -Wl,-rpath=${RUNTIME_LDPATH}/lib ${COMPILETIME_ROOT}
 
 ### LINTER checking ###
-LINTER=clang-tidy -extra-arg=-Wno-unknown-warning-option
+LINTER?=clang-tidy -extra-arg=-Wno-unknown-warning-option
 #second line sets warnings to errors except for certain things
 LINTER_DEFAULT_ARGS=-checks=readability-* --warnings-as-errors=readability-*,-readability-implicit-bool-conversion,-readability-else-after-return,-readability-function-cognitive-complexity,-readability-convert-member-functions-to-static,-clang-diagnostic-unknown-warning-option,-readability-make-member-function-const
 

--- a/src/StatusDisplay/StatusDisplay.cc
+++ b/src/StatusDisplay/StatusDisplay.cc
@@ -184,7 +184,7 @@ namespace BUTool{
       e.Append("Table ");
       e.Append(table.c_str());
       e.Append(" not found\n");
-      throw e;
+      throw e
     }
     return &tables.at(table);
   }

--- a/src/StatusDisplay/StatusDisplay.cc
+++ b/src/StatusDisplay/StatusDisplay.cc
@@ -184,7 +184,7 @@ namespace BUTool{
       e.Append("Table ");
       e.Append(table.c_str());
       e.Append(" not found\n");
-      throw e
+      throw e;
     }
     return &tables.at(table);
   }


### PR DESCRIPTION
This PR introduces a GitHub Actions based CI pipeline for `BUTool`, utilizing the GenericDSAT [plugin](https://gitlab.com/BU-EDF/GenericDSATDevice_plugin/-/tree/develop). This job is ran to check the output from `BUTool::StatusDisplay`, and compare the output status tables with an expected output. 

The main functionality and logic for the tests (e.g. the `BUTool` commands to execute) are defined in the plugin source code linked above. Here, a YAML file defining the GitHub Actions workflow is added.